### PR TITLE
feat: TMDB and OMDB API routes

### DIFF
--- a/apps/web/src/app/api/omdb/route.ts
+++ b/apps/web/src/app/api/omdb/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const OMDB_KEY = process.env.OMDB_API_KEY || '';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const imdbId = searchParams.get('imdbId');
+
+  if (!imdbId) {
+    return NextResponse.json({ rottenTomatoesScore: null });
+  }
+
+  try {
+    const res = await fetch(`https://www.omdbapi.com/?i=${imdbId}&apikey=${OMDB_KEY}`);
+    if (!res.ok) {
+      return NextResponse.json({ rottenTomatoesScore: null });
+    }
+
+    const data = await res.json();
+    const rt = (data.Ratings || []).find((r: any) => r.Source === 'Rotten Tomatoes');
+    const score = rt ? parseInt(rt.Value) : null;
+
+    return NextResponse.json({ rottenTomatoesScore: score });
+  } catch {
+    return NextResponse.json({ rottenTomatoesScore: null });
+  }
+}

--- a/apps/web/src/app/api/tmdb/discover/route.ts
+++ b/apps/web/src/app/api/tmdb/discover/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const TMDB_TOKEN = process.env.TMDB_READ_ACCESS_TOKEN || '';
+const TMDB_BASE = 'https://api.themoviedb.org/3';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const countOnly = searchParams.get('count_only') === 'true';
+  const mediaTypes = (searchParams.get('media_types') || 'movie').split(',');
+  const providers = searchParams.get('providers') || '';
+  const genres = searchParams.get('genres') || '';
+  const minRating = searchParams.get('min_rating') || '0';
+  const region = searchParams.get('region') || 'US';
+  const language = searchParams.get('language') || '';
+  const yearFrom = searchParams.get('year_from') || '2000';
+  const yearTo = searchParams.get('year_to') || new Date().getFullYear().toString();
+  const sortBy = searchParams.get('sort_by') || 'popularity.desc';
+
+  let totalResults = 0;
+  const allResults: any[] = [];
+
+  for (const mediaType of mediaTypes) {
+    const params = new URLSearchParams();
+    if (providers) {
+      params.set('with_watch_providers', providers);
+      params.set('watch_region', region);
+      params.set('with_watch_monetization_types', 'flatrate');
+    }
+    if (genres) params.set('with_genres', genres);
+    if (parseFloat(minRating) > 0) params.set('vote_average.gte', minRating);
+    const dateField = mediaType === 'movie' ? 'primary_release_date' : 'first_air_date';
+    params.set(`${dateField}.gte`, `${yearFrom}-01-01`);
+    params.set(`${dateField}.lte`, `${yearTo}-12-31`);
+    if (language) params.set('with_original_language', language);
+    params.set('sort_by', sortBy);
+    params.set('page', '1');
+
+    try {
+      const res = await fetch(`${TMDB_BASE}/discover/${mediaType}?${params}`, {
+        headers: {
+          'Authorization': `Bearer ${TMDB_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        next: { revalidate: 60 },
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        totalResults += data.total_results;
+        if (!countOnly) {
+          allResults.push(...data.results.map((r: any) => ({ ...r, media_type: mediaType })));
+        }
+      }
+    } catch (err) {
+      console.error(`TMDB discover error for ${mediaType}:`, err);
+    }
+  }
+
+  if (countOnly) {
+    return NextResponse.json({ count: totalResults });
+  }
+
+  return NextResponse.json({ results: allResults, total_results: totalResults });
+}

--- a/apps/web/src/app/api/tmdb/providers/route.ts
+++ b/apps/web/src/app/api/tmdb/providers/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const TMDB_TOKEN = process.env.TMDB_READ_ACCESS_TOKEN || '';
+const TMDB_BASE = 'https://api.themoviedb.org/3';
+const TMDB_IMG = 'https://image.tmdb.org/t/p/w500';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const region = searchParams.get('region') || 'US';
+
+  const providers: Map<number, { id: number; name: string; logoPath: string; priority: number }> = new Map();
+
+  for (const type of ['movie', 'tv']) {
+    try {
+      const res = await fetch(`${TMDB_BASE}/watch/providers/${type}?watch_region=${region}`, {
+        headers: {
+          'Authorization': `Bearer ${TMDB_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        next: { revalidate: 3600 },
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        for (const p of data.results || []) {
+          if (!providers.has(p.provider_id)) {
+            providers.set(p.provider_id, {
+              id: p.provider_id,
+              name: p.provider_name,
+              logoPath: `${TMDB_IMG}${p.logo_path}`,
+              priority: p.display_priority,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`Error fetching ${type} providers:`, err);
+    }
+  }
+
+  const sorted = [...providers.values()]
+    .sort((a, b) => a.priority - b.priority)
+    .map(({ id, name, logoPath }) => ({ id, name, logoPath }));
+
+  return NextResponse.json(sorted);
+}


### PR DESCRIPTION
## Summary
- `/api/tmdb/discover`: proxies TMDB discover with count_only mode for filter preview
- `/api/tmdb/providers`: streaming provider list by region, cached 1 hour
- `/api/omdb`: Rotten Tomatoes score lookup, graceful error handling

All routes use Bearer token auth for TMDB.

Closes #5
Closes #6