### PR TITLE
feat: game history with localStorage

### DIFF
--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -12,6 +12,7 @@ import GameStats from '@/components/results/GameStats';
 import ShareResultButton from '@/components/results/ShareResultButton';
 import Button from '@/components/ui/Button';
 import Logo from '@/components/ui/Logo';
+import { saveGameToHistory } from '@/lib/history';
 
 export default function ResultsPage() {
   const router = useRouter();
@@ -23,6 +24,21 @@ export default function ResultsPage() {
     isFirstMatch, playerId, swipeReveal, gameStats,
   } = useGameStore();
   const [rankingSubmitted, setRankingSubmitted] = useState(false);
+  const [historySaved, setHistorySaved] = useState(false);
+
+  // Save to history when winner is determined
+  useEffect(() => {
+    if (winner && room && !historySaved) {
+      setHistorySaved(true);
+      saveGameToHistory({
+        id: `${code}-${Date.now()}`,
+        date: new Date().toISOString(),
+        players: room.players.map(p => p.displayName),
+        winner: { title: winner.title, posterPath: winner.posterPath },
+        stats: gameStats,
+      });
+    }
+  }, [winner, room, historySaved, code, gameStats]);
 
   useEffect(() => {
     if (!room) {

--- a/apps/web/src/components/landing/GameHistoryButton.tsx
+++ b/apps/web/src/components/landing/GameHistoryButton.tsx
@@ -2,23 +2,28 @@
 
 import { useState } from 'react';
 import { motion } from 'framer-motion';
+import GameHistory from '@/components/results/GameHistory';
 
 export default function GameHistoryButton() {
   const [showHistory, setShowHistory] = useState(false);
 
   return (
-    <motion.div
-      className="mt-8"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ delay: 0.7 }}
-    >
-      <button
-        onClick={() => setShowHistory(!showHistory)}
-        className="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+    <>
+      <motion.div
+        className="mt-8"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.7 }}
       >
-        Game History
-      </button>
-    </motion.div>
+        <button
+          onClick={() => setShowHistory(true)}
+          className="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+        >
+          Game History
+        </button>
+      </motion.div>
+
+      <GameHistory isOpen={showHistory} onClose={() => setShowHistory(false)} />
+    </>
   );
 }

--- a/apps/web/src/components/results/GameHistory.tsx
+++ b/apps/web/src/components/results/GameHistory.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { getGameHistory, clearGameHistory } from '@/lib/history';
+import type { GameHistoryEntry } from '@/types/game';
+import Modal from '@/components/ui/Modal';
+import Button from '@/components/ui/Button';
+
+interface GameHistoryProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function GameHistory({ isOpen, onClose }: GameHistoryProps) {
+  const [history, setHistory] = useState<GameHistoryEntry[]>([]);
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setHistory(getGameHistory());
+    }
+  }, [isOpen]);
+
+  const handleClear = () => {
+    clearGameHistory();
+    setHistory([]);
+    setConfirmClear(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Game History">
+      {history.length === 0 ? (
+        <p className="text-gray-500 text-center py-8">No games played yet</p>
+      ) : (
+        <div className="space-y-3 max-h-[60vh] overflow-y-auto">
+          {history.map((entry) => (
+            <motion.div
+              key={entry.id}
+              className="bg-dark-surface rounded-xl p-3 border border-dark-border"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+            >
+              <div className="flex items-center gap-3">
+                {entry.winner?.posterPath && (
+                  <img
+                    src={entry.winner.posterPath}
+                    alt={entry.winner.title}
+                    className="w-10 h-14 rounded object-cover"
+                  />
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium truncate">
+                    {entry.winner?.title || 'No winner'}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {new Date(entry.date).toLocaleDateString()} &middot; {entry.players.join(', ')}
+                  </p>
+                </div>
+              </div>
+
+              {entry.stats.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-2">
+                  {entry.stats.map(s => (
+                    <span key={s.title} className="text-xs bg-dark-card px-2 py-0.5 rounded">
+                      {s.emoji} {s.playerName}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </motion.div>
+          ))}
+        </div>
+      )}
+
+      {history.length > 0 && (
+        <div className="mt-4 pt-4 border-t border-dark-border">
+          {confirmClear ? (
+            <div className="flex gap-2 justify-center">
+              <Button onClick={handleClear} variant="ghost" size="sm">
+                Yes, Clear All
+              </Button>
+              <Button onClick={() => setConfirmClear(false)} variant="secondary" size="sm">
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <Button onClick={() => setConfirmClear(true)} variant="ghost" size="sm" className="w-full">
+              Clear History
+            </Button>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/apps/web/src/lib/history.ts
+++ b/apps/web/src/lib/history.ts
@@ -1,0 +1,28 @@
+import type { GameHistoryEntry } from '@/types/game';
+
+const STORAGE_KEY = 'showmatch-history';
+
+export function saveGameToHistory(entry: GameHistoryEntry): void {
+  try {
+    const history = getGameHistory();
+    history.unshift(entry);
+    // Keep last 50 games
+    const trimmed = history.slice(0, 50);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+  } catch {}
+}
+
+export function getGameHistory(): GameHistoryEntry[] {
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function clearGameHistory(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- localStorage helpers: save, get, clear (keeps last 50 games)
- GameHistory modal: scrollable list with poster, title, date, players, stats
- Clear History button with confirmation dialog
- Auto-save to history when winner is determined
- Integrated into landing page GameHistoryButton

Closes #15