### PR TITLE
fix: rename next.config.ts to .mjs

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,5 @@
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- Renamed next.config.ts to next.config.mjs for Node.js compatibility
- Next.js 14 requires .js or .mjs config, not .ts