### PR TITLE
Polish results page: lock ranking after submit, winner info flip, better action buttons

### DIFF
--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -9,8 +9,6 @@ import RankingBoard from '@/components/results/RankingBoard';
 import WildcardPicker from '@/components/results/WildcardPicker';
 import SwipeReveal from '@/components/results/SwipeReveal';
 import GameStats from '@/components/results/GameStats';
-import ShareResultButton from '@/components/results/ShareResultButton';
-import Button from '@/components/ui/Button';
 import Logo from '@/components/ui/Logo';
 import { saveGameToHistory } from '@/lib/history';
 
@@ -25,6 +23,7 @@ export default function ResultsPage() {
   } = useGameStore();
   const [rankingSubmitted, setRankingSubmitted] = useState(false);
   const [historySaved, setHistorySaved] = useState(false);
+  const [shareCopied, setShareCopied] = useState(false);
 
   // Auto-set winner when there's exactly 1 match (server skips ranking round)
   useEffect(() => {
@@ -74,7 +73,7 @@ export default function ResultsPage() {
 
   const handleShare = useCallback(async () => {
     if (!winner) return;
-    const text = `We're watching ${winner.title}! Decided on ShowMatch`;
+    const text = `We're watching "${winner.title}" (${winner.year})! Decided on ShowMatch 🎬`;
     if (navigator.share) {
       try {
         await navigator.share({ title: 'ShowMatch Result', text });
@@ -82,6 +81,8 @@ export default function ResultsPage() {
       } catch {}
     }
     await navigator.clipboard.writeText(text);
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 2000);
   }, [winner]);
 
   if (!room) return null;
@@ -154,30 +155,60 @@ export default function ResultsPage() {
             </div>
 
             {/* Action buttons */}
-            <div className="flex gap-3 mt-6">
+            <div className="mt-8 rounded-2xl bg-dark-card border border-dark-border p-4 space-y-3">
+              {/* Share — always visible */}
+              <button
+                onClick={handleShare}
+                className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-dark-border bg-dark-surface hover:bg-dark-border transition-colors text-white font-semibold text-base active:scale-95"
+              >
+                <span className="text-lg">{shareCopied ? '✓' : '📤'}</span>
+                {shareCopied ? 'Copied to clipboard!' : 'Share Result'}
+              </button>
+
+              {/* Creator-only controls */}
               {isCreator && (
                 <>
-                  <Button onClick={handlePlayAgain} variant="secondary" className="flex-1">
+                  <button
+                    onClick={handlePlayAgain}
+                    className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-primary hover:bg-primary-dark transition-colors text-white font-semibold text-base active:scale-95"
+                  >
+                    <span className="text-lg">🔄</span>
                     Play Again
-                  </Button>
-                  <Button onClick={handleEndGame} variant="ghost" className="flex-1">
+                  </button>
+
+                  <button
+                    onClick={handleEndGame}
+                    className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-red-900/40 bg-red-950/30 hover:bg-red-950/60 transition-colors text-red-400 font-semibold text-base active:scale-95"
+                  >
+                    <span className="text-lg">🚪</span>
                     End Game
-                  </Button>
+                  </button>
                 </>
               )}
-              <ShareResultButton winner={winner} />
             </div>
           </>
         )}
 
         {/* Broadening suggestion for no matches */}
         {noMatches && (
-          <div className="text-center mt-6 space-y-3">
-            <p className="text-sm text-gray-500">Try selecting more genres or lowering the rating threshold</p>
+          <div className="mt-6 space-y-3">
+            <p className="text-sm text-gray-500 text-center">Try selecting more genres or lowering the rating threshold</p>
             {isCreator && (
-              <div className="flex gap-3 justify-center">
-                <Button onClick={handlePlayAgain} variant="secondary">Play Again</Button>
-                <Button onClick={handleEndGame} variant="ghost">End Game</Button>
+              <div className="rounded-2xl bg-dark-card border border-dark-border p-4 space-y-3">
+                <button
+                  onClick={handlePlayAgain}
+                  className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-primary hover:bg-primary-dark transition-colors text-white font-semibold text-base active:scale-95"
+                >
+                  <span className="text-lg">🔄</span>
+                  Play Again
+                </button>
+                <button
+                  onClick={handleEndGame}
+                  className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-red-900/40 bg-red-950/30 hover:bg-red-950/60 transition-colors text-red-400 font-semibold text-base active:scale-95"
+                >
+                  <span className="text-lg">🚪</span>
+                  End Game
+                </button>
               </div>
             )}
           </div>

--- a/apps/web/src/components/results/RankingBoard.tsx
+++ b/apps/web/src/components/results/RankingBoard.tsx
@@ -28,13 +28,13 @@ export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoa
         You agreed on {titles.length} titles! Rank them.
       </h2>
 
-      <Reorder.Group axis="y" values={items} onReorder={setItems}>
-        {items.map((item, index) => (
-          <Reorder.Item key={item.tmdbId} value={item}>
-            <motion.div
-              className="flex items-center gap-3 bg-dark-card rounded-xl p-3 mb-2 border border-dark-border cursor-grab active:cursor-grabbing"
-              whileDrag={{ scale: 1.02, boxShadow: '0 0 20px rgba(229,9,20,0.3)' }}
-              layout
+      {submitted ? (
+        // Locked static list after submission
+        <div className="space-y-2">
+          {items.map((item, index) => (
+            <div
+              key={item.tmdbId}
+              className="flex items-center gap-3 bg-dark-card rounded-xl p-3 mb-2 border border-dark-border opacity-60"
             >
               <span className="text-lg font-bold text-primary w-8 text-center">{index + 1}</span>
               {item.posterPath && (
@@ -44,11 +44,34 @@ export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoa
                 <p className="font-medium truncate">{item.title}</p>
                 <p className="text-xs text-gray-500">{item.year} &middot; &#9733; {item.voteAverage.toFixed(1)}</p>
               </div>
-              <div className="text-gray-600 text-xl cursor-grab">&#9776;</div>
-            </motion.div>
-          </Reorder.Item>
-        ))}
-      </Reorder.Group>
+              <span className="text-green-400 text-lg">✓</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        // Draggable list before submission
+        <Reorder.Group axis="y" values={items} onReorder={setItems}>
+          {items.map((item, index) => (
+            <Reorder.Item key={item.tmdbId} value={item}>
+              <motion.div
+                className="flex items-center gap-3 bg-dark-card rounded-xl p-3 mb-2 border border-dark-border cursor-grab active:cursor-grabbing"
+                whileDrag={{ scale: 1.02, boxShadow: '0 0 20px rgba(229,9,20,0.3)' }}
+                layout
+              >
+                <span className="text-lg font-bold text-primary w-8 text-center">{index + 1}</span>
+                {item.posterPath && (
+                  <img src={item.posterPath} alt={item.title} className="w-10 h-14 rounded object-cover" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium truncate">{item.title}</p>
+                  <p className="text-xs text-gray-500">{item.year} &middot; &#9733; {item.voteAverage.toFixed(1)}</p>
+                </div>
+                <div className="text-gray-600 text-xl cursor-grab">&#9776;</div>
+              </motion.div>
+            </Reorder.Item>
+          ))}
+        </Reorder.Group>
+      )}
 
       <Button
         size="lg"
@@ -56,7 +79,7 @@ export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoa
         disabled={submitted}
         className="w-full"
       >
-        {submitted ? 'Rankings Submitted!' : 'Submit Rankings'}
+        {submitted ? '✓ Rankings Submitted' : 'Submit Rankings'}
       </Button>
     </div>
   );

--- a/apps/web/src/components/results/ResultReveal.tsx
+++ b/apps/web/src/components/results/ResultReveal.tsx
@@ -13,6 +13,7 @@ interface ResultRevealProps {
 export default function ResultReveal({ winner, skipCountdown = false }: ResultRevealProps) {
   const [countdown, setCountdown] = useState(skipCountdown ? 0 : 3);
   const [revealed, setRevealed] = useState(skipCountdown);
+  const [flipped, setFlipped] = useState(false);
 
   useEffect(() => {
     if (skipCountdown) return;
@@ -47,24 +48,119 @@ export default function ResultReveal({ winner, skipCountdown = false }: ResultRe
           >
             <Confetti />
             <h2 className="text-2xl font-bold mb-4 text-accent-gold">Tonight&apos;s Pick!</h2>
-            <div className="bg-dark-card rounded-2xl overflow-hidden border border-dark-border max-w-xs mx-auto shadow-2xl">
-              {winner.posterPath && (
-                <img
-                  src={winner.posterPath}
-                  alt={winner.title}
-                  className="w-full aspect-[2/3] object-cover"
-                />
-              )}
-              <div className="p-4">
-                <h3 className="text-xl font-bold">{winner.title}</h3>
-                <p className="text-gray-400">({winner.year})</p>
-                <div className="flex justify-center gap-3 mt-2 text-sm">
-                  <span>&#9733; {winner.voteAverage.toFixed(1)}</span>
-                  {winner.rottenTomatoesScore !== null && (
-                    <span>&#127813; {winner.rottenTomatoesScore}%</span>
-                  )}
+
+            {/* Flip card container */}
+            <div
+              className="relative max-w-xs mx-auto cursor-pointer select-none"
+              style={{ perspective: 1200 }}
+              onClick={() => setFlipped(f => !f)}
+            >
+              {/* Front face */}
+              <motion.div
+                className="bg-dark-card rounded-2xl overflow-hidden border border-dark-border shadow-2xl"
+                animate={{ rotateY: flipped ? 180 : 0 }}
+                transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
+                style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d' }}
+              >
+                {winner.posterPath && (
+                  <img
+                    src={winner.posterPath}
+                    alt={winner.title}
+                    className="w-full aspect-[2/3] object-cover"
+                  />
+                )}
+                <div className="p-4 space-y-2">
+                  <h3 className="text-xl font-bold">{winner.title}</h3>
+                  <p className="text-gray-400">({winner.year})</p>
+                  <div className="flex justify-center gap-3 text-sm">
+                    <span className="flex items-center gap-1">
+                      <span className="text-yellow-400">★</span>
+                      <span>{winner.voteAverage.toFixed(1)}</span>
+                      <span className="text-gray-600 text-xs">IMDB</span>
+                    </span>
+                    {winner.rottenTomatoesScore !== null && (
+                      <span className="flex items-center gap-1">
+                        <span>🍅</span>
+                        <span>{winner.rottenTomatoesScore}%</span>
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-600 pt-1">Tap for details ↕</p>
                 </div>
-              </div>
+              </motion.div>
+
+              {/* Back face */}
+              <motion.div
+                className="absolute inset-0 bg-dark-card rounded-2xl border border-dark-border shadow-2xl overflow-hidden"
+                animate={{ rotateY: flipped ? 360 : 180 }}
+                transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
+                style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d' }}
+              >
+                <div className="p-5 h-full overflow-y-auto space-y-4 text-left">
+                  <h3 className="text-xl font-bold leading-tight">
+                    {winner.title}{' '}
+                    <span className="text-gray-500 font-normal text-base">({winner.year})</span>
+                  </h3>
+
+                  <div className="flex gap-3 flex-wrap">
+                    <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
+                      <div className="text-yellow-400 text-lg font-bold">{winner.voteAverage.toFixed(1)}</div>
+                      <div className="text-xs text-gray-500">IMDB</div>
+                    </div>
+                    {winner.rottenTomatoesScore !== null && (
+                      <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
+                        <div className="text-red-400 text-lg font-bold">{winner.rottenTomatoesScore}%</div>
+                        <div className="text-xs text-gray-500">RT</div>
+                      </div>
+                    )}
+                    {winner.runtime && (
+                      <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
+                        <div className="text-lg font-bold">
+                          {winner.runtime >= 60
+                            ? `${Math.floor(winner.runtime / 60)}h ${winner.runtime % 60}m`
+                            : `${winner.runtime}m`}
+                        </div>
+                        <div className="text-xs text-gray-500">Runtime</div>
+                      </div>
+                    )}
+                  </div>
+
+                  {winner.contentRating && (
+                    <span className="inline-block px-2 py-1 bg-dark-surface border border-dark-border rounded text-xs font-bold">
+                      {winner.contentRating}
+                    </span>
+                  )}
+
+                  {winner.overview && (
+                    <p className="text-sm text-gray-300 leading-relaxed">{winner.overview}</p>
+                  )}
+
+                  {winner.cast && winner.cast.length > 0 && (
+                    <p className="text-sm">
+                      <span className="text-gray-500">Starring: </span>{winner.cast.join(', ')}
+                    </p>
+                  )}
+                  {winner.director && (
+                    <p className="text-sm">
+                      <span className="text-gray-500">Directed by: </span>{winner.director}
+                    </p>
+                  )}
+
+                  {winner.trailerKey && (
+                    <a
+                      href={`https://www.youtube.com/watch?v=${winner.trailerKey}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 rounded-lg text-sm font-medium transition-colors"
+                      onClick={e => e.stopPropagation()}
+                    >
+                      ▶ Watch Trailer
+                    </a>
+                  )}
+
+                  <p className="text-xs text-gray-600 text-center pb-2">Tap to flip back ↕</p>
+                </div>
+              </motion.div>
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
## Changes

### 🔒 Lock ranking board after submit
- After clicking **Submit Rankings**, the drag-to-reorder list freezes into a static locked view
- Items show ✓ checkmarks and are dimmed (opacity 60%)
- No more accidental reordering after submitting

### 📋 Tap-to-flip info on winner card
- Winner card on the results screen now supports the same **tap-to-flip** interaction as the swipe cards
- Back side shows: rating badges (IMDB / RT / Runtime), content rating, overview, cast, director, and trailer link
- "Tap for details ↕" hint at the bottom

### 🎨 Redesigned action buttons
- Replaced the plain flat button row with a **card section** (dark background, border)
- **Share Result** → full-width, border style with 📤 icon; shows "Copied to clipboard!" on clipboard fallback
- **Play Again** → full-width primary red with 🔄 icon (creator only)
- **End Game** → full-width red-tinted ghost with 🚪 icon (creator only)
- Same treatment applied to the no-matches flow buttons