### PR TITLE
Fix streaming provider sort: best regional priority, no 20-item cap

### DIFF
--- a/apps/web/src/app/api/tmdb/providers/route.ts
+++ b/apps/web/src/app/api/tmdb/providers/route.ts
@@ -23,13 +23,17 @@ export async function GET(request: NextRequest) {
       if (res.ok) {
         const data = await res.json();
         for (const p of data.results || []) {
-          if (!providers.has(p.provider_id)) {
+          const existing = providers.get(p.provider_id);
+          if (!existing) {
             providers.set(p.provider_id, {
               id: p.provider_id,
               name: p.provider_name,
               logoPath: `${TMDB_IMG}${p.logo_path}`,
               priority: p.display_priority,
             });
+          } else if (p.display_priority < existing.priority) {
+            // Keep the best (lowest) priority across movie + tv
+            existing.priority = p.display_priority;
           }
         }
       }

--- a/apps/web/src/components/lobby/FilterPanel.tsx
+++ b/apps/web/src/components/lobby/FilterPanel.tsx
@@ -111,7 +111,7 @@ export default function FilterPanel({ settings, onSettingsChange, isCreator }: F
         )}
 
         <div className="grid grid-cols-4 gap-2 max-h-40 overflow-y-auto">
-          {providers.slice(0, 20).map(p => (
+          {providers.map(p => (
             <button
               key={p.id}
               onClick={() => update({ providers: toggleInArray(settings.providers, p.id) })}


### PR DESCRIPTION
## Changes

**`providers/route.ts`** — take minimum `display_priority` when a provider appears in both movie and TV endpoints. Previously, whichever endpoint was fetched first "won", which could give a suboptimal rank. Now the provider always gets its best (lowest) regional priority score.

**`FilterPanel.tsx`** — remove `slice(0, 20)`. TMDB already filters results to the selected region, so the list is naturally bounded (~30–50 items). The grid container already has `max-h-40 overflow-y-auto` so it scrolls cleanly.