### PR TITLE
Fix card providers filter, mobile confetti, winner streaming logos

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -122,16 +122,28 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
       title.trailerKey = trailer?.key || null;
     }
 
-    // Providers
+    // Providers — flatrate (subscription) only, strip platform sub-channels
     if (providersRes.status === 'fulfilled' && providersRes.value.ok) {
       const providersData = await providersRes.value.json();
       const regionData = providersData.results?.[region];
       const flatrate = regionData?.flatrate || [];
-      title.providers = flatrate.map((p: any) => ({
-        id: p.provider_id,
-        name: p.provider_name,
-        logoPath: `${TMDB_IMG}${p.logo_path}`,
-      }));
+      const CHANNEL_PATTERNS = [
+        /apple tv channel/i,
+        /amazon channel/i,
+        /prime video channel/i,
+        /roku channel/i,
+        /\bchannel$/i,
+        /\bstore\b/i,
+        /itunes/i,
+        /google play/i,
+      ];
+      title.providers = flatrate
+        .filter((p: any) => !CHANNEL_PATTERNS.some((re: RegExp) => re.test(p.provider_name)))
+        .map((p: any) => ({
+          id: p.provider_id,
+          name: p.provider_name,
+          logoPath: `${TMDB_IMG}${p.logo_path}`,
+        }));
     }
 
     // External IDs + OMDB (movies only)

--- a/apps/web/src/components/results/Confetti.tsx
+++ b/apps/web/src/components/results/Confetti.tsx
@@ -6,27 +6,38 @@ export default function Confetti() {
   useEffect(() => {
     import('canvas-confetti').then(mod => {
       const confetti = mod.default;
-      const duration = 3000;
+      const duration = 3500;
       const end = Date.now() + duration;
 
-      const frame = () => {
+      // Burst from both sides — more particles + useWorker:false for mobile compat
+      const fire = (opts: object) =>
         confetti({
-          particleCount: 3,
-          angle: 60,
-          spread: 55,
-          origin: { x: 0 },
-          colors: ['#e50914', '#ffd700', '#00c853'],
-        });
-        confetti({
-          particleCount: 3,
-          angle: 120,
-          spread: 55,
-          origin: { x: 1 },
-          colors: ['#e50914', '#ffd700', '#00c853'],
+          particleCount: 6,
+          spread: 60,
+          ticks: 200,
+          gravity: 1.2,
+          scalar: 1.1,
+          colors: ['#e50914', '#ffd700', '#00c853', '#ffffff', '#ff69b4'],
+          disableForReducedMotion: true,
+          useWorker: false,
+          ...opts,
         });
 
+      const frame = () => {
+        fire({ angle: 60, origin: { x: 0, y: 0.6 } });
+        fire({ angle: 120, origin: { x: 1, y: 0.6 } });
         if (Date.now() < end) requestAnimationFrame(frame);
       };
+
+      // Initial big burst
+      confetti({
+        particleCount: 80,
+        spread: 100,
+        origin: { y: 0.5 },
+        colors: ['#e50914', '#ffd700', '#00c853'],
+        disableForReducedMotion: true,
+        useWorker: false,
+      });
 
       frame();
     });

--- a/apps/web/src/components/results/ResultReveal.tsx
+++ b/apps/web/src/components/results/ResultReveal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { TitleCard } from '@/types/game';
 import Confetti from './Confetti';
+import StreamingLogos from '@/components/game/StreamingLogos';
 
 interface ResultRevealProps {
   winner: TitleCard;
@@ -85,6 +86,11 @@ export default function ResultReveal({ winner, skipCountdown = false }: ResultRe
                       </span>
                     )}
                   </div>
+                  {winner.providers && winner.providers.length > 0 && (
+                    <div className="flex justify-center pt-1">
+                      <StreamingLogos providers={winner.providers} />
+                    </div>
+                  )}
                   <p className="text-xs text-gray-600 pt-1">Tap for details ↕</p>
                 </div>
               </motion.div>
@@ -144,6 +150,10 @@ export default function ResultReveal({ winner, skipCountdown = false }: ResultRe
                     <p className="text-sm">
                       <span className="text-gray-500">Directed by: </span>{winner.director}
                     </p>
+                  )}
+
+                  {winner.providers && winner.providers.length > 0 && (
+                    <StreamingLogos providers={winner.providers} />
                   )}
 
                   {winner.trailerKey && (


### PR DESCRIPTION
**Card providers filter** — socket server's `enrichTitle` now applies the same sub-channel name patterns (`/apple tv channel/i`, `/amazon channel/i`, `/channel$/i`, etc.) to the flatrate array before storing on each `TitleCard`. Flatrate already excludes rental/purchase; this adds the channel dedup.

**Mobile confetti** — rewritten with `useWorker: false` (Safari/Chrome mobile compat), higher particle count (6/frame vs 3), and an initial 80-particle burst so it's visible immediately on small screens.

**Winner streaming logos** — `StreamingLogos` component added to both the front face (centered below ratings) and back face (above trailer link) of the winner card in `ResultReveal`.