### PR TITLE
Robust region detection: Intl.Locale + timezone fallback

### DIFF
--- a/apps/web/src/components/lobby/FilterPanel.tsx
+++ b/apps/web/src/components/lobby/FilterPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { motion } from 'framer-motion';
 import type { GameSettings, StreamingProvider } from '@/types/game';
 import { GENRES, CONTENT_RATINGS, TIMER_OPTIONS, SORT_OPTIONS } from '@/lib/constants';
+import { detectRegion } from '@/lib/detectRegion';
 import RangeSlider from '@/components/ui/RangeSlider';
 
 interface FilterPanelProps {
@@ -32,22 +33,14 @@ export default function FilterPanel({ settings, onSettingsChange, isCreator }: F
     setProviderTooltip(null);
   }, []);
 
-  // Auto-detect region from browser locale on first mount
+  // Auto-detect region from browser locale / timezone on first mount
   const regionDetected = useRef(false);
   useEffect(() => {
     if (!isCreator || regionDetected.current) return;
     regionDetected.current = true;
-
-    const langs = [navigator.language, ...(navigator.languages ?? [])];
-    for (const lang of langs) {
-      const parts = lang.split('-');
-      if (parts.length >= 2) {
-        const detected = parts[parts.length - 1].toUpperCase();
-        if (detected !== settings.region) {
-          onSettingsChange({ ...settings, region: detected });
-        }
-        break;
-      }
+    const detected = detectRegion();
+    if (detected !== settings.region) {
+      onSettingsChange({ ...settings, region: detected });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCreator]);

--- a/apps/web/src/components/results/Confetti.tsx
+++ b/apps/web/src/components/results/Confetti.tsx
@@ -9,9 +9,10 @@ export default function Confetti() {
       const duration = 3500;
       const end = Date.now() + duration;
 
-      // Burst from both sides — more particles + useWorker:false for mobile compat
+      // Burst from both sides — more particles, useWorker:false for mobile compat
+      // (cast to any to bypass outdated type definitions)
       const fire = (opts: object) =>
-        confetti({
+        (confetti as any)({
           particleCount: 6,
           spread: 60,
           ticks: 200,
@@ -30,7 +31,7 @@ export default function Confetti() {
       };
 
       // Initial big burst
-      confetti({
+      (confetti as any)({
         particleCount: 80,
         spread: 100,
         origin: { y: 0.5 },

--- a/apps/web/src/lib/detectRegion.ts
+++ b/apps/web/src/lib/detectRegion.ts
@@ -1,0 +1,84 @@
+/**
+ * Detect the user's ISO 3166-1 alpha-2 country code.
+ *
+ * Priority:
+ * 1. Intl.Locale — parses navigator.language[s] and returns `.region` directly
+ *    (most reliable on modern Android/iOS; handles "he-IL", "en-IL", etc.)
+ * 2. Manual tag parse — fallback for older browsers that support navigator.languages
+ *    but not Intl.Locale
+ * 3. IANA timezone → country map — works even when the user's UI language is set
+ *    to English (e.g. "en-US" on an Israeli phone); the system timezone is
+ *    always set to the actual location
+ */
+
+const TZ_TO_COUNTRY: Record<string, string> = {
+  // Middle East
+  'Asia/Jerusalem': 'IL', 'Asia/Tel_Aviv': 'IL',
+  'Asia/Dubai': 'AE', 'Asia/Riyadh': 'SA', 'Asia/Qatar': 'QA',
+  'Asia/Amman': 'JO', 'Asia/Beirut': 'LB', 'Asia/Baghdad': 'IQ',
+  'Asia/Kuwait': 'KW', 'Asia/Muscat': 'OM', 'Asia/Bahrain': 'BH',
+  'Asia/Istanbul': 'TR',
+  // Europe
+  'Europe/London': 'GB', 'Europe/Paris': 'FR', 'Europe/Berlin': 'DE',
+  'Europe/Amsterdam': 'NL', 'Europe/Madrid': 'ES', 'Europe/Rome': 'IT',
+  'Europe/Warsaw': 'PL', 'Europe/Lisbon': 'PT', 'Europe/Stockholm': 'SE',
+  'Europe/Oslo': 'NO', 'Europe/Copenhagen': 'DK', 'Europe/Helsinki': 'FI',
+  'Europe/Athens': 'GR', 'Europe/Bucharest': 'RO', 'Europe/Budapest': 'HU',
+  'Europe/Prague': 'CZ', 'Europe/Vienna': 'AT', 'Europe/Brussels': 'BE',
+  'Europe/Zurich': 'CH', 'Europe/Kyiv': 'UA', 'Europe/Moscow': 'RU',
+  'Europe/Dublin': 'IE',
+  // North America
+  'America/New_York': 'US', 'America/Chicago': 'US', 'America/Denver': 'US',
+  'America/Los_Angeles': 'US', 'America/Phoenix': 'US', 'America/Anchorage': 'US',
+  'Pacific/Honolulu': 'US', 'America/Toronto': 'CA', 'America/Vancouver': 'CA',
+  'America/Edmonton': 'CA', 'America/Winnipeg': 'CA', 'America/Halifax': 'CA',
+  'America/Mexico_City': 'MX',
+  // South America
+  'America/Sao_Paulo': 'BR', 'America/Buenos_Aires': 'AR',
+  'America/Bogota': 'CO', 'America/Santiago': 'CL', 'America/Lima': 'PE',
+  // Asia-Pacific
+  'Asia/Tokyo': 'JP', 'Asia/Seoul': 'KR', 'Asia/Shanghai': 'CN',
+  'Asia/Hong_Kong': 'HK', 'Asia/Kolkata': 'IN', 'Asia/Singapore': 'SG',
+  'Asia/Bangkok': 'TH', 'Asia/Jakarta': 'ID', 'Asia/Manila': 'PH',
+  'Asia/Taipei': 'TW', 'Asia/Kuala_Lumpur': 'MY',
+  'Australia/Sydney': 'AU', 'Australia/Melbourne': 'AU', 'Australia/Perth': 'AU',
+  'Pacific/Auckland': 'NZ',
+  // Africa
+  'Africa/Cairo': 'EG', 'Africa/Johannesburg': 'ZA', 'Africa/Lagos': 'NG',
+  'Africa/Nairobi': 'KE', 'Africa/Casablanca': 'MA',
+};
+
+export function detectRegion(): string {
+  if (typeof window === 'undefined') return 'US';
+
+  // 1. Intl.Locale — gives .region directly
+  try {
+    const langs = [navigator.language, ...(navigator.languages ?? [])];
+    for (const lang of langs) {
+      const locale = new Intl.Locale(lang);
+      if (locale.region && locale.region.length === 2) {
+        return locale.region.toUpperCase();
+      }
+    }
+  } catch {}
+
+  // 2. Manual parse — split on '-' or '_', take last 2-char segment
+  try {
+    const langs = [navigator.language, ...(navigator.languages ?? [])];
+    for (const lang of langs) {
+      const parts = lang.split(/[-_]/);
+      const last = parts[parts.length - 1];
+      if (parts.length >= 2 && last.length === 2) {
+        return last.toUpperCase();
+      }
+    }
+  } catch {}
+
+  // 3. Timezone → country (works when UI language is set to English)
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (TZ_TO_COUNTRY[tz]) return TZ_TO_COUNTRY[tz];
+  } catch {}
+
+  return 'US';
+}


### PR DESCRIPTION
Previous implementation split `navigator.language` on `'-'` — unreliable when users have English UI (`en-US`) on an Israeli phone.

**New `detectRegion()` utility (3-layer):**
1. `Intl.Locale(lang).region` — modern API, handles `he-IL`, `en-IL`, etc. correctly
2. Manual tag parse — older browser fallback
3. IANA timezone → country lookup — `Asia/Jerusalem` → `IL` regardless of UI language; 50+ common timezones mapped

Extracted into `lib/detectRegion.ts` for reuse.