### PR TITLE
Fix endGame button (silent fail) + instant host-disconnect on finished games

### DIFF
--- a/apps/socket-server/src/handlers/roomHandler.ts
+++ b/apps/socket-server/src/handlers/roomHandler.ts
@@ -51,21 +51,30 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
     socket.leave(room.code);
   });
 
-  socket.on('endGame', () => {
-    if (!roomManager.isCreator(socket.id)) return;
-
-    const room = roomManager.getRoomBySocket(socket.id);
+  socket.on('endGame', (payload?: { playerId?: string }) => {
+    // Find room by current socket or by stored playerId (survives reconnects)
+    const room = roomManager.getRoomBySocket(socket.id)
+      ?? (payload?.playerId ? roomManager.getRoomByPlayerId(payload.playerId) : null);
     if (!room) return;
+
+    const isCreator = room.players.find(
+      p => p.id === socket.id || p.id === payload?.playerId
+    )?.isCreator ?? false;
+    if (!isCreator) return;
 
     io.to(room.code).emit('roomClosed', 'Game ended by host');
     roomManager.destroyRoom(room.code);
   });
 
-  socket.on('playAgain', () => {
-    if (!roomManager.isCreator(socket.id)) return;
-
-    const room = roomManager.getRoomBySocket(socket.id);
+  socket.on('playAgain', (payload?: { playerId?: string }) => {
+    const room = roomManager.getRoomBySocket(socket.id)
+      ?? (payload?.playerId ? roomManager.getRoomByPlayerId(payload.playerId) : null);
     if (!room) return;
+
+    const isCreator = room.players.find(
+      p => p.id === socket.id || p.id === payload?.playerId
+    )?.isCreator ?? false;
+    if (!isCreator) return;
 
     room.status = 'lobby';
     room.titlePool = [];

--- a/apps/socket-server/src/state/RoomManager.ts
+++ b/apps/socket-server/src/state/RoomManager.ts
@@ -130,6 +130,14 @@ class RoomManager {
     return this.rooms.get(code) || null;
   }
 
+  /** Find the room that has a player with this ID (survives socket reconnects). */
+  getRoomByPlayerId(playerId: string): Room | null {
+    for (const room of this.rooms.values()) {
+      if (room.players.some(p => p.id === playerId)) return room;
+    }
+    return null;
+  }
+
   getPlayerBySocket(socketId: string): Player | null {
     const room = this.getRoomBySocket(socketId);
     if (!room) return null;
@@ -144,6 +152,12 @@ class RoomManager {
     if (!player) return null;
 
     player.connected = false;
+
+    // No grace period for finished games — fire immediately
+    if (room.status === 'finished') {
+      onExpire(room, player);
+      return { room, player };
+    }
 
     const timerKey = `${room.code}:${socketId}`;
     const timer = setTimeout(() => {

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -64,12 +64,12 @@ export default function ResultsPage() {
   }, [socket]);
 
   const handlePlayAgain = useCallback(() => {
-    socket.emit('playAgain');
-  }, [socket]);
+    socket.emit('playAgain', { playerId });
+  }, [socket, playerId]);
 
   const handleEndGame = useCallback(() => {
-    socket.emit('endGame');
-  }, [socket]);
+    socket.emit('endGame', { playerId });
+  }, [socket, playerId]);
 
   const handleShare = useCallback(async () => {
     if (!winner) return;


### PR DESCRIPTION
## Root causes

**endGame does nothing:** `isCreator(socket.id)` returns false after any socket reconnect (e.g. server restart, brief network drop). The room still has the OLD socket ID; the new socket has no mapping in `socketToRoom`. Handler silently returns.

**Host disconnect not immediate:** `handleDisconnect` always waits 60 seconds before firing `roomClosed`. Fine during lobby/swiping (allows reconnect), wrong when the game is already finished — players sit staring at the results screen for a minute.

## Fixes
- `endGame`/`playAgain` now accept `{ playerId }` payload — the original join-time socket ID stored in the game store
- Server looks up room via `getRoomBySocket` OR new `getRoomByPlayerId` fallback; creator verified by either socket.id or stored playerId  
- `handleDisconnect`: fires `onExpire` immediately (no grace period) when `room.status === 'finished'`