### PR TITLE
Fix play again (stale gameOver + race) and share button on HTTP

### DIFF
--- a/apps/socket-server/src/state/RoomManager.ts
+++ b/apps/socket-server/src/state/RoomManager.ts
@@ -153,17 +153,14 @@ class RoomManager {
 
     player.connected = false;
 
-    // No grace period for finished games — fire immediately
-    if (room.status === 'finished') {
-      onExpire(room, player);
-      return { room, player };
-    }
-
     const timerKey = `${room.code}:${socketId}`;
+    // Finished rooms: 5s grace (feels responsive, survives brief reconnects).
+    // Active rooms: 60s grace (allows reconnect mid-game).
+    const graceMs = room.status === 'finished' ? 5_000 : 60_000;
     const timer = setTimeout(() => {
       this.disconnectTimers.delete(timerKey);
       onExpire(room, player);
-    }, 60 * 1000);
+    }, graceMs);
 
     this.disconnectTimers.set(timerKey, timer);
 

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -74,13 +74,30 @@ export default function ResultsPage() {
   const handleShare = useCallback(async () => {
     if (!winner) return;
     const text = `We're watching "${winner.title}" (${winner.year})! Decided on ShowMatch 🎬`;
+
+    // navigator.share works on mobile (HTTPS or localhost)
     if (navigator.share) {
       try {
         await navigator.share({ title: 'ShowMatch Result', text });
         return;
       } catch {}
     }
-    await navigator.clipboard.writeText(text);
+
+    // navigator.clipboard requires HTTPS/localhost — falls back to execCommand
+    // which works on any origin (including LAN HTTP)
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      const el = document.createElement('textarea');
+      el.value = text;
+      el.style.position = 'fixed';
+      el.style.opacity = '0';
+      document.body.appendChild(el);
+      el.focus();
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+    }
     setShareCopied(true);
     setTimeout(() => setShareCopied(false), 2000);
   }, [winner]);

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -67,6 +67,9 @@ export function useSocket() {
     });
 
     (socket as any).on('roomReset', (room: any) => {
+      // Reset game-specific flags so the new game starts clean.
+      // Don't call store.reset() — that would wipe playerId.
+      store.setGameOver(false);
       store.setRoom(room);
     });
 


### PR DESCRIPTION
## Play Again

**Bug 1 — stale `gameOver`:** `roomReset` handler only called `store.setRoom(room)`, leaving `gameOver: true`. When the new game started and the player landed on the game page, the `gameOver` guard immediately redirected them back to the results page. Fix: call `store.setGameOver(false)` in the `roomReset` handler.

**Bug 2 — instant-destroy race:** Previous PR set finished-room grace to 0ms. Any brief socket reconnect (tsx watch restart, network hiccup) on the results screen would destroy the room before Play Again could fire. Fix: 5s grace for finished rooms (fast enough to feel responsive, safe for real reconnects).

## Share Button

`navigator.clipboard.writeText` throws `NotAllowedError` on non-HTTPS origins (LAN access via `192.168.x.x`). Fix: try clipboard API first, fall back to `document.execCommand('copy')` which works on any HTTP origin.