### PR TITLE
Add hover tooltips for all truncated short-text elements

### DIFF
--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -126,7 +126,7 @@ export default function SwipeCard({
 
             {/* Info strip */}
             <div className="p-4 space-y-2">
-              <h2 className="text-lg font-bold truncate">
+              <h2 className="text-lg font-bold truncate" title={card.title}>
                 {card.title} <span className="text-gray-500 font-normal text-base">({card.year})</span>
               </h2>
 

--- a/apps/web/src/components/lobby/FilterPanel.tsx
+++ b/apps/web/src/components/lobby/FilterPanel.tsx
@@ -139,6 +139,7 @@ export default function FilterPanel({ settings, onSettingsChange, isCreator }: F
               className={`flex flex-col items-center gap-1 p-2 rounded-lg transition-colors ${
                 settings.providers.includes(p.id) ? 'bg-primary/20 ring-1 ring-primary' : 'bg-dark-surface'
               }`}
+              title={p.name}
             >
               <img src={p.logoPath} alt={p.name} className="w-8 h-8 rounded-md" />
               <span className="text-[10px] text-gray-400 truncate w-full text-center">{p.name}</span>

--- a/apps/web/src/components/lobby/PlayerList.tsx
+++ b/apps/web/src/components/lobby/PlayerList.tsx
@@ -25,7 +25,7 @@ export default function PlayerList({ players }: PlayerListProps) {
             layout
           >
             <PlayerAvatar name={player.displayName} connected={player.connected} />
-            <span className="font-medium flex-1 truncate">{player.displayName}</span>
+            <span className="font-medium flex-1 truncate" title={player.displayName}>{player.displayName}</span>
             {player.isCreator && <span className="text-accent-gold text-sm" title="Room creator">👑</span>}
             <span className={`w-2 h-2 rounded-full ${player.connected ? 'bg-accent-green' : 'bg-gray-600'}`} />
           </motion.div>

--- a/apps/web/src/components/results/GameHistory.tsx
+++ b/apps/web/src/components/results/GameHistory.tsx
@@ -50,7 +50,7 @@ export default function GameHistory({ isOpen, onClose }: GameHistoryProps) {
                   />
                 )}
                 <div className="flex-1 min-w-0">
-                  <p className="font-medium truncate">
+                  <p className="font-medium truncate" title={entry.winner?.title || 'No winner'}>
                     {entry.winner?.title || 'No winner'}
                   </p>
                   <p className="text-xs text-gray-500">

--- a/apps/web/src/components/results/RankingBoard.tsx
+++ b/apps/web/src/components/results/RankingBoard.tsx
@@ -41,7 +41,7 @@ export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoa
                 <img src={item.posterPath} alt={item.title} className="w-10 h-14 rounded object-cover" />
               )}
               <div className="flex-1 min-w-0">
-                <p className="font-medium truncate">{item.title}</p>
+                <p className="font-medium truncate" title={item.title}>{item.title}</p>
                 <p className="text-xs text-gray-500">{item.year} &middot; &#9733; {item.voteAverage.toFixed(1)}</p>
               </div>
               <span className="text-green-400 text-lg">✓</span>
@@ -63,7 +63,7 @@ export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoa
                   <img src={item.posterPath} alt={item.title} className="w-10 h-14 rounded object-cover" />
                 )}
                 <div className="flex-1 min-w-0">
-                  <p className="font-medium truncate">{item.title}</p>
+                  <p className="font-medium truncate" title={item.title}>{item.title}</p>
                   <p className="text-xs text-gray-500">{item.year} &middot; &#9733; {item.voteAverage.toFixed(1)}</p>
                 </div>
                 <div className="text-gray-600 text-xl cursor-grab">&#9776;</div>

--- a/apps/web/src/components/results/SwipeReveal.tsx
+++ b/apps/web/src/components/results/SwipeReveal.tsx
@@ -29,7 +29,7 @@ export default function SwipeReveal({ reveals }: SwipeRevealProps) {
               <img src={title.posterPath} alt={title.title} className="w-8 h-12 rounded object-cover" />
             )}
             <div className="flex-1 min-w-0">
-              <p className="text-sm truncate">{title.title}</p>
+              <p className="text-sm truncate" title={title.title}>{title.title}</p>
               <div className="flex gap-1 mt-1 flex-wrap">
                 {playerDecisions.map(pd => (
                   <span

--- a/apps/web/src/components/results/WildcardPicker.tsx
+++ b/apps/web/src/components/results/WildcardPicker.tsx
@@ -60,7 +60,7 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
             }`}
           >
             {c.posterPath && <img src={c.posterPath} alt={c.title} className="w-full aspect-[2/3] object-cover" />}
-            <p className="text-xs p-1 truncate">{c.title}</p>
+            <p className="text-xs p-1 truncate" title={c.title}>{c.title}</p>
           </motion.div>
         ))}
       </div>


### PR DESCRIPTION
Adds `title` attribute (native browser tooltip on hover) to every element that uses `truncate` and displays short identifying text — names and titles only, not long-form text.

**Added to:**
- Streaming provider button in FilterPanel (restores `title` removed when long-press was added; both work independently)
- Movie/show title in SwipeCard
- Ranking items in RankingBoard (locked + draggable states)
- Player names in PlayerList
- Matched title in SwipeReveal
- Wildcard candidate in WildcardPicker
- Winner title in GameHistory

**Not added to:** overviews, cast lists, genre tags, or any other long-form text.