### PR TITLE
Fix clipboard on plain HTTP (LAN access)

### DIFF
--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -11,6 +11,7 @@ import SwipeReveal from '@/components/results/SwipeReveal';
 import GameStats from '@/components/results/GameStats';
 import Logo from '@/components/ui/Logo';
 import { saveGameToHistory } from '@/lib/history';
+import { safeCopy } from '@/lib/clipboard';
 
 export default function ResultsPage() {
   const router = useRouter();
@@ -83,21 +84,7 @@ export default function ResultsPage() {
       } catch {}
     }
 
-    // navigator.clipboard requires HTTPS/localhost — falls back to execCommand
-    // which works on any origin (including LAN HTTP)
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch {
-      const el = document.createElement('textarea');
-      el.value = text;
-      el.style.position = 'fixed';
-      el.style.opacity = '0';
-      document.body.appendChild(el);
-      el.focus();
-      el.select();
-      document.execCommand('copy');
-      document.body.removeChild(el);
-    }
+    await safeCopy(text);
     setShareCopied(true);
     setTimeout(() => setShareCopied(false), 2000);
   }, [winner]);

--- a/apps/web/src/components/lobby/ShareButton.tsx
+++ b/apps/web/src/components/lobby/ShareButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { safeCopy } from '@/lib/clipboard';
 
 interface ShareButtonProps {
   code: string;
@@ -8,6 +9,11 @@ interface ShareButtonProps {
 
 export default function ShareButton({ code }: ShareButtonProps) {
   const [copied, setCopied] = useState(false);
+
+  const flash = () => {
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   const handleShare = async () => {
     const text = `Join my ShowMatch game! Code: ${code}`;
@@ -20,15 +26,13 @@ export default function ShareButton({ code }: ShareButtonProps) {
       } catch { /* User cancelled or not supported */ }
     }
 
-    await navigator.clipboard.writeText(`${text}\n${url}`);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    await safeCopy(`${text}\n${url}`);
+    flash();
   };
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    await safeCopy(code);
+    flash();
   };
 
   return (

--- a/apps/web/src/components/results/ShareResultButton.tsx
+++ b/apps/web/src/components/results/ShareResultButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { TitleCard } from '@/types/game';
 import Button from '@/components/ui/Button';
+import { safeCopy } from '@/lib/clipboard';
 
 interface ShareResultButtonProps {
   winner: TitleCard;
@@ -21,7 +22,7 @@ export default function ShareResultButton({ winner }: ShareResultButtonProps) {
       } catch {}
     }
 
-    await navigator.clipboard.writeText(text);
+    await safeCopy(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -1,0 +1,22 @@
+/**
+ * Copy text to clipboard in a way that works on plain HTTP (LAN access).
+ * - Prefers navigator.clipboard (modern, async) when available
+ * - Falls back to document.execCommand('copy') which works on any origin
+ */
+export async function safeCopy(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return;
+  } catch {
+    // Fallback for non-HTTPS origins (e.g. 192.168.x.x on LAN)
+    const el = document.createElement('textarea');
+    el.value = text;
+    el.style.position = 'fixed';
+    el.style.opacity = '0';
+    document.body.appendChild(el);
+    el.focus();
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+  }
+}


### PR DESCRIPTION
`navigator.clipboard.writeText` requires HTTPS or localhost — throws `NotAllowedError` on `192.168.x.x`.

**Fix:** `lib/clipboard.ts` — `safeCopy(text)` tries `navigator.clipboard` first, falls back to `document.execCommand('copy')` (works on any HTTP origin).

Applied to:
- `ShareButton` (lobby — Copy Code + Share invite)
- `ShareResultButton` (results page component)
- Inline share handler in `results/[code]/page.tsx`