### PR TITLE
Fix sounds: replace Howler with Audio, wire gestures + match/victory

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -27,6 +27,13 @@ export default function GamePage() {
     recordSwipe, undoLastSwipe, playerId,
   } = useGameStore();
   const { playLike, playPass, playSuperLike } = useSound();
+
+  // Sound is driven from handleSwipe so it fires for both gestures AND button taps
+  const soundForDecision = useCallback((decision: 'like' | 'pass' | 'superlike') => {
+    if (decision === 'like') playLike();
+    else if (decision === 'pass') playPass();
+    else playSuperLike();
+  }, [playLike, playPass, playSuperLike]);
   const [flipped, setFlipped] = useState(false);
   const [showTutorial, setShowTutorial] = useState(false);
   const [canUndo, setCanUndo] = useState(false);
@@ -56,6 +63,7 @@ export default function GamePage() {
     if (!titlePool[currentCardIndex]) return;
     const tmdbId = titlePool[currentCardIndex].tmdbId;
 
+    soundForDecision(decision);
     socket.emit('submitSwipe', tmdbId, decision);
     recordSwipe({ tmdbId, decision, timestamp: Date.now() });
     setFlipped(false);
@@ -69,7 +77,7 @@ export default function GamePage() {
         navigator.vibrate?.(50);
       }
     } catch {}
-  }, [socket, titlePool, currentCardIndex, recordSwipe]);
+  }, [socket, titlePool, currentCardIndex, recordSwipe, soundForDecision]);
 
   const handleUndo = useCallback(() => {
     const undone = undoLastSwipe();
@@ -145,9 +153,9 @@ export default function GamePage() {
           <div className="flex items-center justify-center gap-4">
             <UndoButton onClick={handleUndo} disabled={!canUndo} />
             <SwipeButtons
-              onPass={() => { playPass(); setPendingDecision('pass'); }}
-              onLike={() => { playLike(); setPendingDecision('like'); }}
-              onSuperLike={() => { playSuperLike(); setPendingDecision('superlike'); }}
+              onPass={() => setPendingDecision('pass')}
+              onLike={() => setPendingDecision('like')}
+              onSuperLike={() => setPendingDecision('superlike')}
               superLikeUsed={me?.superLikeUsed ?? false}
               disabled={isFinished || !!pendingDecision}
             />

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -65,11 +65,11 @@ export default function ResultsPage() {
   }, [socket]);
 
   const handlePlayAgain = useCallback(() => {
-    socket.emit('playAgain', { playerId });
+    (socket as any).emit('playAgain', { playerId });
   }, [socket, playerId]);
 
   const handleEndGame = useCallback(() => {
-    socket.emit('endGame', { playerId });
+    (socket as any).emit('endGame', { playerId });
   }, [socket, playerId]);
 
   const handleShare = useCallback(async () => {

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { connectSocket, getSocket } from '@/lib/socket';
 import { useGameStore } from '@/stores/gameStore';
+import { playSound } from '@/lib/sounds';
 import type { Socket } from 'socket.io-client';
 
 export function useSocket() {
@@ -40,6 +41,7 @@ export function useSocket() {
     socket.on('allPlayersFinished', (matchedTitles) => {
       store.setMatchedTitles(matchedTitles);
       store.setGameOver(true);
+      if (matchedTitles.length > 0) playSound('match');
     });
 
     socket.on('firstMatch', (title) => {
@@ -47,6 +49,7 @@ export function useSocket() {
       store.setWinner(title);
       store.setMatchedTitles([title]);
       store.setGameOver(true);
+      playSound('victory');
     });
 
     socket.on('rankingsReady', (winner, rankings) => {

--- a/apps/web/src/hooks/useSound.ts
+++ b/apps/web/src/hooks/useSound.ts
@@ -1,56 +1,22 @@
 'use client';
 
-import { useRef, useEffect, useCallback } from 'react';
-import { Howl } from 'howler';
-import { SOUND_FILES, type SoundName } from '@/lib/sounds';
-
-const MUTE_KEY = 'showmatch-muted';
+import { useCallback } from 'react';
+import { playSound, toggleMuteSound, isSoundMuted } from '@/lib/sounds';
 
 export function useSound() {
-  const soundsRef = useRef<Record<string, Howl>>({});
-  const mutedRef = useRef(false);
-
-  useEffect(() => {
-    mutedRef.current = localStorage.getItem(MUTE_KEY) === 'true';
-
-    // Preload all sounds
-    for (const [name, src] of Object.entries(SOUND_FILES)) {
-      soundsRef.current[name] = new Howl({
-        src: [src],
-        volume: 0.5,
-        preload: true,
-      });
-    }
-
-    return () => {
-      Object.values(soundsRef.current).forEach(s => s.unload());
-    };
-  }, []);
-
-  const play = useCallback((name: SoundName) => {
-    if (mutedRef.current) return;
-    soundsRef.current[name]?.play();
-  }, []);
-
-  const toggleMute = useCallback(() => {
-    mutedRef.current = !mutedRef.current;
-    localStorage.setItem(MUTE_KEY, String(mutedRef.current));
-    return mutedRef.current;
-  }, []);
-
-  const isMuted = useCallback(() => mutedRef.current, []);
+  const play = useCallback((name: Parameters<typeof playSound>[0]) => playSound(name), []);
 
   return {
-    playLike: () => play('like'),
-    playPass: () => play('pass'),
+    playLike:      () => play('like'),
+    playPass:      () => play('pass'),
     playSuperLike: () => play('superlike'),
-    playMatch: () => play('match'),
-    playVictory: () => play('victory'),
-    playFlip: () => play('flip'),
-    playTick: () => play('tick'),
-    playTimeout: () => play('timeout'),
-    playWildcard: () => play('wildcard'),
-    toggleMute,
-    isMuted,
+    playMatch:     () => play('match'),
+    playVictory:   () => play('victory'),
+    playFlip:      () => play('flip'),
+    playTick:      () => play('tick'),
+    playTimeout:   () => play('timeout'),
+    playWildcard:  () => play('wildcard'),
+    toggleMute:    toggleMuteSound,
+    isMuted:       isSoundMuted,
   };
 }

--- a/apps/web/src/lib/sounds.ts
+++ b/apps/web/src/lib/sounds.ts
@@ -1,17 +1,53 @@
 'use client';
 
-const SOUND_FILES = {
-  like: '/sounds/like.mp3',
-  pass: '/sounds/pass.mp3',
+export const SOUND_FILES = {
+  like:      '/sounds/like.mp3',
+  pass:      '/sounds/pass.mp3',
   superlike: '/sounds/superlike.mp3',
-  match: '/sounds/match.mp3',
-  victory: '/sounds/victory.mp3',
-  flip: '/sounds/flip.mp3',
-  tick: '/sounds/tick.mp3',
-  timeout: '/sounds/timeout.mp3',
-  wildcard: '/sounds/wildcard.mp3',
+  match:     '/sounds/match.mp3',
+  victory:   '/sounds/victory.mp3',
+  flip:      '/sounds/flip.mp3',
+  tick:      '/sounds/tick.mp3',
+  timeout:   '/sounds/timeout.mp3',
+  wildcard:  '/sounds/wildcard.mp3',
 } as const;
 
 export type SoundName = keyof typeof SOUND_FILES;
 
-export { SOUND_FILES };
+// ---------- module-level singleton (no AudioContext, works on all mobile browsers) ----------
+
+const cache: Partial<Record<SoundName, HTMLAudioElement>> = {};
+let muted = false;
+
+function getAudio(name: SoundName): HTMLAudioElement | null {
+  if (typeof window === 'undefined') return null;
+  if (!cache[name]) {
+    const el = new Audio(SOUND_FILES[name]);
+    el.volume = 0.5;
+    el.preload = 'auto';
+    cache[name] = el;
+  }
+  return cache[name]!;
+}
+
+/** Play a sound. Safe to call anywhere (SSR-safe, catches autoplay errors silently). */
+export function playSound(name: SoundName): void {
+  if (typeof window === 'undefined' || muted) return;
+  const el = getAudio(name);
+  if (!el) return;
+  el.currentTime = 0;
+  el.play().catch(() => {});   // ignore NotAllowedError on browsers that need a gesture first
+}
+
+export function toggleMuteSound(): boolean {
+  muted = !muted;
+  try { localStorage.setItem('showmatch-muted', String(muted)); } catch {}
+  return muted;
+}
+
+export function isSoundMuted(): boolean { return muted; }
+
+// Restore mute preference from localStorage on first import
+if (typeof window !== 'undefined') {
+  try { muted = localStorage.getItem('showmatch-muted') === 'true'; } catch {}
+}


### PR DESCRIPTION
## Root causes

1. **Howler AudioContext fails silently on mobile** — Howler uses Web Audio API which starts suspended and needs unlocking; can fail on iOS/Android without any error
2. **Gesture swipes had no sound** — `playLike/Pass/SuperLike` were only called in the `SwipeButtons` click handlers; dragging the card called `handleSwipe` directly, completely bypassing sounds
3. **Match/victory sounds never fired** — `playMatch` and `playVictory` existed but were never called

## Fixes
- **`lib/sounds.ts`**: module-level singleton with `new Audio()` — no AudioContext, works everywhere, SSR-safe, lazy-loads on first play
- **`useSound.ts`**: thin wrapper; drops Howler entirely
- **Game page**: `soundForDecision()` called inside `handleSwipe` (fires for both gestures and buttons); removed duplicate calls from button handlers
- **`useSocket.ts`**: `playSound('match')` on `allPlayersFinished` with matches; `playSound('victory')` on `firstMatch`