### PR TITLE
Dedup per-title providers: collapse Netflix/Netflix with Ads etc.

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -137,8 +137,24 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
         /itunes/i,
         /google play/i,
       ];
+      // Normalize name for dedup: strip tier suffixes and platform distribution
+      // so "Netflix" and "Netflix Standard with Ads" collapse to the same key
+      const normalizeProviderName = (s: string) =>
+        s.toLowerCase()
+          .replace(/\s+(apple tv|amazon|prime video|roku).*$/i, '')
+          .replace(/[^a-z0-9]/g, '')
+          .replace(/(basic|standard|premium|kids|plus|hd|4k|withadvertisements|withads|ads)$/g, '')
+          .trim();
+
+      const seenProviders = new Set<string>();
       title.providers = flatrate
         .filter((p: any) => !CHANNEL_PATTERNS.some((re: RegExp) => re.test(p.provider_name)))
+        .filter((p: any) => {
+          const key = normalizeProviderName(p.provider_name);
+          if (seenProviders.has(key)) return false;
+          seenProviders.add(key);
+          return true;
+        })
         .map((p: any) => ({
           id: p.provider_id,
           name: p.provider_name,


### PR DESCRIPTION
The per-title `flatrate` list from TMDB can contain multiple tiers for the same service — e.g. `Netflix` (id 8) and `Netflix Standard with Ads` (id 1796). The channel-pattern filter didn't catch these because they don't contain 'channel'/'store' keywords.

**Fix:** after the channel filter, normalize each name (lowercase, strip punctuation, strip tier suffixes: `basic`, `standard`, `premium`, `ads`, `withadvertisements`, etc.) and deduplicate by that key. TMDB's flatrate list is ordered by display priority, so the most prominent variant (plain `Netflix`) wins.