### PR TITLE
fix: remove maxHeight from poster to prevent cropping

### DIFF
--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -109,9 +109,9 @@ export default function SwipeCard({
             transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
             style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d' }}
           >
-            {/* Poster — aspect-[2/3] matches TMDB poster ratio so no cropping needed */}
+            {/* Poster — aspect-[2/3] matches TMDB poster ratio, no maxHeight so nothing gets cropped */}
             <div className="relative bg-dark-surface w-full overflow-hidden"
-              style={{ aspectRatio: '2/3', maxHeight: '58vh' }}>
+              style={{ aspectRatio: '2/3' }}>
               {card.posterPath ? (
                 <img
                   src={card.posterPath}


### PR DESCRIPTION
## Problem
The poster container had both `aspectRatio: '2/3'` and `maxHeight: '58vh'`.

On mobile, the natural poster height (card width × 1.5) often exceeds 58vh. When that happens, `maxHeight` wins but the **width stays full-width** — breaking the aspect ratio. With `object-cover`, the image stretches to fill the now-taller-than-2:3 box and crops the poster top/bottom.

## Fix
Remove `maxHeight: '58vh'` from the poster div. The `aspectRatio: '2/3'` constraint is sufficient — the container is always the correct 2:3 shape, so `object-cover object-center` fills it exactly with zero cropping.

## Files Changed
- `apps/web/src/components/game/SwipeCard.tsx` — removed `maxHeight` from poster wrapper style