### PR TITLE
fix: host leave/end-game reliably notifies all guests

### DIFF
--- a/apps/socket-server/src/handlers/roomHandler.ts
+++ b/apps/socket-server/src/handlers/roomHandler.ts
@@ -34,19 +34,23 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
     console.log(`${playerName} joined room ${code}`);
   });
 
-  socket.on('leaveRoom', () => {
-    const room = roomManager.getRoomBySocket(socket.id);
+  socket.on('leaveRoom', (payload?: { playerId?: string }) => {
+    // Support playerId fallback so this works even after a socket reconnect
+    const room = roomManager.getRoomBySocket(socket.id)
+      ?? (payload?.playerId ? roomManager.getRoomByPlayerId(payload.playerId) : null);
     if (!room) return;
 
-    const player = room.players.find(p => p.id === socket.id);
+    const player = room.players.find(
+      p => p.id === socket.id || p.id === payload?.playerId
+    );
     if (!player) return;
 
     if (player.isCreator) {
       io.to(room.code).emit('roomClosed', 'Host left the game');
       roomManager.destroyRoom(room.code);
     } else {
-      roomManager.removePlayer(room.code, socket.id);
-      socket.to(room.code).emit('playerLeft', socket.id);
+      roomManager.removePlayer(room.code, player.id);
+      socket.to(room.code).emit('playerLeft', player.id);
     }
     socket.leave(room.code);
   });
@@ -93,17 +97,13 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
 }
 
 export function handleDisconnect(io: Server, socket: Socket) {
-  const result = roomManager.handleDisconnect(socket.id, (room, player) => {
+  roomManager.handleDisconnect(socket.id, (room, player) => {
     if (player.isCreator) {
-      io.to(room.code).emit('roomClosed', 'Host left the game');
+      io.to(room.code).emit('roomClosed', 'Host disconnected');
       roomManager.destroyRoom(room.code);
     } else {
       roomManager.removePlayer(room.code, player.id);
       io.to(room.code).emit('playerLeft', player.id);
     }
   });
-
-  if (result) {
-    socket.to(result.room.code).emit('playerLeft', result.player.id);
-  }
 }

--- a/apps/socket-server/src/state/RoomManager.ts
+++ b/apps/socket-server/src/state/RoomManager.ts
@@ -155,8 +155,12 @@ class RoomManager {
 
     const timerKey = `${room.code}:${socketId}`;
     // Finished rooms: 5s grace (feels responsive, survives brief reconnects).
-    // Active rooms: 60s grace (allows reconnect mid-game).
-    const graceMs = room.status === 'finished' ? 5_000 : 60_000;
+    // Host in active game: 15s grace — long enough to survive a brief network blip,
+    //   short enough that guests don't wait forever if the host leaves for real.
+    // Other players: 60s grace (allows full reconnect mid-game).
+    const graceMs = room.status === 'finished'
+      ? 5_000
+      : (player.isCreator ? 15_000 : 60_000);
     const timer = setTimeout(() => {
       this.disconnectTimers.delete(timerKey);
       onExpire(room, player);

--- a/apps/web/src/components/ui/Logo.tsx
+++ b/apps/web/src/components/ui/Logo.tsx
@@ -15,10 +15,12 @@ interface LogoProps {
 export default function Logo({ size = 'sm' }: LogoProps) {
   const textSize = size === 'lg' ? 'text-5xl md:text-6xl' : 'text-2xl';
   const router = useRouter();
-  const { room, reset } = useGameStore();
+  const { room, reset, playerId } = useGameStore();
   const [showConfirm, setShowConfirm] = useState(false);
 
-  const isInGame = room?.status === 'swiping' || room?.status === 'ranking';
+  // Show leave-confirmation and emit leaveRoom whenever the player is inside a running game
+  // (any status except lobby — lobby is fine to exit freely)
+  const isInGame = !!room && room.status !== 'lobby';
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -32,7 +34,7 @@ export default function Logo({ size = 'sm' }: LogoProps) {
   const handleLeave = () => {
     try {
       const socket = getSocket();
-      socket.emit('leaveRoom');
+      socket.emit('leaveRoom', { playerId: playerId ?? undefined });
     } catch {}
     reset();
     setShowConfirm(false);

--- a/apps/web/src/hooks/useBeforeUnload.ts
+++ b/apps/web/src/hooks/useBeforeUnload.ts
@@ -6,18 +6,19 @@ import { useGameStore } from '@/stores/gameStore';
 
 export function useBeforeUnload() {
   const room = useGameStore(s => s.room);
+  const playerId = useGameStore(s => s.playerId);
 
   useEffect(() => {
     const handler = () => {
       if (room) {
         try {
           const socket = getSocket();
-          socket.emit('leaveRoom');
+          socket.emit('leaveRoom', { playerId: playerId ?? undefined });
         } catch {}
       }
     };
 
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
-  }, [room]);
+  }, [room, playerId]);
 }

--- a/apps/web/src/types/socket.ts
+++ b/apps/web/src/types/socket.ts
@@ -25,7 +25,7 @@ export interface ClientToServerEvents {
   submitSwipe: (tmdbId: number, decision: 'like' | 'pass' | 'superlike') => void;
   undoSwipe: () => void;
   submitRanking: (rankings: Array<{ tmdbId: number; rank: number }>) => void;
-  playAgain: () => void;
-  endGame: () => void;
-  leaveRoom: () => void;
+  playAgain: (payload?: { playerId?: string }) => void;
+  endGame: (payload?: { playerId?: string }) => void;
+  leaveRoom: (payload?: { playerId?: string }) => void;
 }


### PR DESCRIPTION
## Three root causes fixed

### 1. `leaveRoom` had no `playerId` fallback
Unlike `endGame`, the server's `leaveRoom` handler only looked up the room by `socket.id`. If the host's socket reconnected before they clicked Leave, `getRoomBySocket` returned null and the handler silently bailed — guests saw nothing.

**Fix:** `leaveRoom` now accepts `{ playerId? }` and falls back to `getRoomByPlayerId()`, mirroring the existing `endGame` handler.

---

### 2. Logo `isInGame` check too narrow
`isInGame` only checked for `swiping | ranking`. When the host was on the **results page** (`room.status === 'finished'`) and tapped the Logo, `isInGame` was `false` → no confirmation modal, no `leaveRoom` emitted → host navigated away silently, guests stuck.

**Fix:** `isInGame = !!room && room.status !== 'lobby'` — any non-lobby status triggers the Leave prompt and emits `leaveRoom`.

---

### 3. Host disconnect had a 60s grace period
If the host's browser crashed or phone died mid-game, guests waited **60 full seconds** before receiving `roomClosed`.

**Fix:** Creator grace period reduced to **15 s** for active games (enough to survive a brief Wi-Fi → cellular switch, short enough guests aren't left hanging). Non-creator grace stays at 60 s.

---

### Bonus: fixed double `playerLeft` emit
`handleDisconnect` was emitting `playerLeft` twice for non-creator disconnects (once in the callback, once in the outer code). Removed the duplicate.

## Files Changed
- `apps/web/src/types/socket.ts` — updated `leaveRoom` / `endGame` / `playAgain` signatures to accept optional `{ playerId? }`
- `apps/web/src/components/ui/Logo.tsx` — extended `isInGame`, pass `playerId` with emit
- `apps/web/src/hooks/useBeforeUnload.ts` — pass `playerId` with `leaveRoom` emit
- `apps/socket-server/src/handlers/roomHandler.ts` — `leaveRoom` playerId fallback; fixed `handleDisconnect` double-emit
- `apps/socket-server/src/state/RoomManager.ts` — 15s grace for creator, 60s for others