### PR TITLE
fix: game-ended toast shown to guests only, not the host

### DIFF
--- a/apps/socket-server/src/handlers/roomHandler.ts
+++ b/apps/socket-server/src/handlers/roomHandler.ts
@@ -46,7 +46,8 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
     if (!player) return;
 
     if (player.isCreator) {
-      io.to(room.code).emit('roomClosed', 'Host left the game');
+      // socket.to() excludes the sender — host navigates themselves on the client
+      socket.to(room.code).emit('roomClosed', 'Host left the game');
       roomManager.destroyRoom(room.code);
     } else {
       roomManager.removePlayer(room.code, player.id);
@@ -66,7 +67,8 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
     )?.isCreator ?? false;
     if (!isCreator) return;
 
-    io.to(room.code).emit('roomClosed', 'Game ended by host');
+    // socket.to() excludes the sender — host navigates themselves on the client
+    socket.to(room.code).emit('roomClosed', 'Game ended by host');
     roomManager.destroyRoom(room.code);
   });
 

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -20,7 +20,7 @@ export default function ResultsPage() {
   const socket = useSocket();
   const {
     room, matchedTitles, winner, fullRankings, wildcardCandidates,
-    isFirstMatch, playerId, swipeReveal, gameStats, gameOver, setWinner,
+    isFirstMatch, playerId, swipeReveal, gameStats, gameOver, setWinner, reset,
   } = useGameStore();
   const [rankingSubmitted, setRankingSubmitted] = useState(false);
   const [historySaved, setHistorySaved] = useState(false);
@@ -70,7 +70,11 @@ export default function ResultsPage() {
 
   const handleEndGame = useCallback(() => {
     (socket as any).emit('endGame', { playerId });
-  }, [socket, playerId]);
+    // Host navigates themselves — server will notify guests via socket.to() (not io.to())
+    // so the host won't receive the roomClosed toast.
+    reset();
+    router.push('/');
+  }, [socket, playerId, reset, router]);
 
   const handleShare = useCallback(async () => {
     if (!winner) return;


### PR DESCRIPTION
## Problem
`endGame` and `leaveRoom` used `io.to(room.code)` which broadcasts `roomClosed` to **all** players in the room — including the host. So the host landed on the home screen and saw "Game ended by host" as if they were a guest.

## Fix

**Server** (`roomHandler.ts`):
- `endGame` and `leaveRoom` (creator path) now use `socket.to(room.code)` instead of `io.to(room.code)`.
- `socket.to()` excludes the sender — guests receive the notification, host does not.
- `handleDisconnect` and `playAgain` stay as `io.to()` (correct: in disconnect the host is already gone; for playAgain the host needs the `roomReset` event too).

**Client** (`results/[code]/page.tsx`):
- `handleEndGame` now calls `reset() + router.push('/')` directly after emitting, since the host no longer receives `roomClosed` from the server.