### PR TITLE
feat: shared provider-filter — single source of truth for both cards and winner

### DIFF
--- a/apps/socket-server/package.json
+++ b/apps/socket-server/package.json
@@ -8,16 +8,17 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "express": "^4.18.0",
-    "socket.io": "^4.7.0",
+    "@showmatch/shared": "^1.0.0",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.0",
+    "express": "^4.18.0",
     "nanoid": "^3.3.7",
-    "dotenv": "^16.4.0"
+    "socket.io": "^4.7.0"
   },
   "devDependencies": {
-    "typescript": "^5.3.0",
-    "@types/express": "^4.17.21",
     "@types/cors": "^2.8.17",
-    "tsx": "^4.7.0"
+    "@types/express": "^4.17.21",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
   }
 }

--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -1,4 +1,5 @@
 import { GameSettings, TitleCard } from '../types';
+import { filterProviders } from '@showmatch/shared';
 
 const TMDB_BASE = 'https://api.themoviedb.org/3';
 const TMDB_IMG = 'https://image.tmdb.org/t/p/w500';
@@ -122,44 +123,18 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
       title.trailerKey = trailer?.key || null;
     }
 
-    // Providers — flatrate (subscription) only, strip platform sub-channels
+    // Providers — flatrate (subscription) only, filtered via shared util
+    // (same logic as the web app's /api/tmdb/providers route)
     if (providersRes.status === 'fulfilled' && providersRes.value.ok) {
       const providersData = await providersRes.value.json();
       const regionData = providersData.results?.[region];
       const flatrate = regionData?.flatrate || [];
-      const CHANNEL_PATTERNS = [
-        /apple tv channel/i,
-        /amazon channel/i,
-        /prime video channel/i,
-        /roku channel/i,
-        /\bchannel$/i,
-        /\bstore\b/i,
-        /itunes/i,
-        /google play/i,
-      ];
-      // Normalize name for dedup: strip tier suffixes and platform distribution
-      // so "Netflix" and "Netflix Standard with Ads" collapse to the same key
-      const normalizeProviderName = (s: string) =>
-        s.toLowerCase()
-          .replace(/\s+(apple tv|amazon|prime video|roku).*$/i, '')
-          .replace(/[^a-z0-9]/g, '')
-          .replace(/(basic|standard|premium|kids|plus|hd|4k|withadvertisements|withads|ads)$/g, '')
-          .trim();
 
-      const seenProviders = new Set<string>();
-      title.providers = flatrate
-        .filter((p: any) => !CHANNEL_PATTERNS.some((re: RegExp) => re.test(p.provider_name)))
-        .filter((p: any) => {
-          const key = normalizeProviderName(p.provider_name);
-          if (seenProviders.has(key)) return false;
-          seenProviders.add(key);
-          return true;
-        })
-        .map((p: any) => ({
-          id: p.provider_id,
-          name: p.provider_name,
-          logoPath: `${TMDB_IMG}${p.logo_path}`,
-        }));
+      title.providers = filterProviders(flatrate).map((p: any) => ({
+        id: p.provider_id,
+        name: p.provider_name,
+        logoPath: `${TMDB_IMG}${p.logo_path}`,
+      }));
     }
 
     // External IDs + OMDB (movies only)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,23 +8,24 @@
     "start": "next start"
   },
   "dependencies": {
+    "@showmatch/shared": "^1.0.0",
+    "canvas-confetti": "^1.9.0",
+    "framer-motion": "^11.0.0",
+    "howler": "^2.2.4",
     "next": "^14.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "framer-motion": "^11.0.0",
     "socket.io-client": "^4.7.0",
-    "zustand": "^4.5.0",
-    "howler": "^2.2.4",
-    "canvas-confetti": "^1.9.0"
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
-    "typescript": "^5.3.0",
+    "@types/canvas-confetti": "^1.6.4",
+    "@types/howler": "^2.2.11",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@types/howler": "^2.2.11",
-    "@types/canvas-confetti": "^1.6.4",
-    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0"
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.3.0"
   }
 }

--- a/apps/web/src/app/api/tmdb/providers/route.ts
+++ b/apps/web/src/app/api/tmdb/providers/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { filterProviders } from '@showmatch/shared';
 
 const TMDB_TOKEN = process.env.TMDB_READ_ACCESS_TOKEN || '';
 const TMDB_BASE = 'https://api.themoviedb.org/3';
@@ -8,7 +9,8 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const region = searchParams.get('region') || 'US';
 
-  const providers: Map<number, { id: number; name: string; logoPath: string; priority: number }> = new Map();
+  // Aggregate providers across movie + tv, keeping the best regional priority
+  const byId = new Map<number, { provider_id: number; provider_name: string; logo_path: string; display_priority: number }>();
 
   for (const type of ['movie', 'tv']) {
     try {
@@ -23,17 +25,9 @@ export async function GET(request: NextRequest) {
       if (res.ok) {
         const data = await res.json();
         for (const p of data.results || []) {
-          const existing = providers.get(p.provider_id);
-          if (!existing) {
-            providers.set(p.provider_id, {
-              id: p.provider_id,
-              name: p.provider_name,
-              logoPath: `${TMDB_IMG}${p.logo_path}`,
-              priority: p.display_priority,
-            });
-          } else if (p.display_priority < existing.priority) {
-            // Keep the best (lowest) priority across movie + tv
-            existing.priority = p.display_priority;
+          const existing = byId.get(p.provider_id);
+          if (!existing || p.display_priority < existing.display_priority) {
+            byId.set(p.provider_id, p);
           }
         }
       }
@@ -42,65 +36,12 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // IDs to exclude: rental/purchase stores and known non-subscription services
-  const EXCLUDED_IDS = new Set([
-    2,   // Apple iTunes
-    3,   // Google Play Movies
-    7,   // Fandango at Home (was Vudu)
-    10,  // Amazon Video (rental)
-    35,  // Rakuten TV
-    68,  // Microsoft Store
-    192, // YouTube (rental/purchase)
-    188, // YouTube Premium
-    207, // Redbox
-    258, // Hoopla
-  ]);
+  // Sort by priority, then run through the shared filter (excludes stores,
+  // sub-channels, deduplicates tier variants) with a hard cap of 30.
+  const sorted = [...byId.values()].sort((a, b) => a.display_priority - b.display_priority);
+  const filtered = filterProviders(sorted, 30);
 
-  // Name patterns to exclude:
-  // - Stores / rental services
-  // - Sub-channel add-ons sold through a platform (e.g. "BET+ Apple TV Channel",
-  //   "AMC+ Amazon Channel") — these are distribution wrappers, not standalone services
-  const EXCLUDED_NAME_PATTERNS = [
-    /itunes/i,
-    /google play/i,
-    /microsoft store/i,
-    /fandango/i,
-    /redbox/i,
-    /\bstore\b/i,
-    /\brent\b/i,
-    // Platform add-on channels — "X Apple TV Channel", "X Amazon Channel", etc.
-    /apple tv channel/i,
-    /amazon channel/i,
-    /prime video channel/i,
-    /roku channel/i,
-    /\bchannel$/i,   // anything ending in bare "Channel" (e.g. "Starz Channel")
-  ];
-
-  const shouldExclude = (p: { id: number; name: string }) =>
-    EXCLUDED_IDS.has(p.id) || EXCLUDED_NAME_PATTERNS.some(re => re.test(p.name));
-
-  // Normalize name for dedup: strip punctuation + tier/plan suffixes,
-  // and strip platform distribution suffixes so "Netflix" and "Netflix Basic"
-  // collapse to the same key.
-  const normalize = (s: string) =>
-    s.toLowerCase()
-      .replace(/\s+(apple tv|amazon|prime video|roku).*$/i, '') // strip " Apple TV..." suffix
-      .replace(/[^a-z0-9]/g, '')
-      .replace(/(basic|standard|premium|kids|plus|hd|4k)$/g, '')
-      .trim();
-
-  const seenNames = new Set<string>();
-  const sorted = [...providers.values()]
-    .sort((a, b) => a.priority - b.priority)
-    .filter(p => !shouldExclude(p))
-    .filter(p => {
-      const key = normalize(p.name);
-      if (seenNames.has(key)) return false;
-      seenNames.add(key);
-      return true;
-    })
-    .slice(0, 30)  // cap at top 30 by regional priority
-    .map(({ id, name, logoPath }) => ({ id, name, logoPath }));
-
-  return NextResponse.json(sorted);
+  return NextResponse.json(
+    filtered.map(p => ({ id: p.provider_id, name: p.provider_name, logoPath: `${TMDB_IMG}${p.logo_path}` }))
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "showmatch",
       "workspaces": [
-        "apps/*"
+        "apps/*",
+        "packages/*"
       ],
       "devDependencies": {
         "concurrently": "^8.0.0"
@@ -16,6 +17,7 @@
       "name": "showmatch-socket-server",
       "version": "0.1.0",
       "dependencies": {
+        "@showmatch/shared": "^1.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.0",
         "express": "^4.18.0",
@@ -33,6 +35,7 @@
       "name": "showmatch-web",
       "version": "0.1.0",
       "dependencies": {
+        "@showmatch/shared": "^1.0.0",
         "canvas-confetti": "^1.9.0",
         "framer-motion": "^11.0.0",
         "howler": "^2.2.4",
@@ -770,6 +773,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@showmatch/shared": {
+      "resolved": "packages/shared",
+      "link": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -3878,6 +3885,10 @@
           "optional": true
         }
       }
+    },
+    "packages/shared": {
+      "name": "@showmatch/shared",
+      "version": "1.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "showmatch",
   "private": true,
-  "workspaces": ["apps/*"],
+  "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "dev": "concurrently \"npm run dev --workspace=apps/web\" \"npm run dev --workspace=apps/socket-server\"",
     "dev:web": "npm run dev --workspace=apps/web",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@showmatch/shared",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts"
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './providerFilter';

--- a/packages/shared/src/providerFilter.ts
+++ b/packages/shared/src/providerFilter.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared provider-filtering logic used by both the socket server (enrichTitle)
+ * and the Next.js web app (providers API route + filter panel).
+ *
+ * Single source of truth: fix here and both places stay in sync.
+ */
+
+/** Minimal shape of a TMDB watch-provider object. */
+export interface RawProvider {
+  provider_id: number;
+  provider_name: string;
+  logo_path?: string;
+  display_priority?: number;
+}
+
+/**
+ * Provider IDs to always exclude.
+ * These are rental/purchase stores or non-subscription services that
+ * should never appear as streaming options.
+ */
+export const EXCLUDED_PROVIDER_IDS = new Set([
+  2,   // Apple iTunes
+  3,   // Google Play Movies
+  7,   // Fandango at Home (was Vudu)
+  10,  // Amazon Video (rental/purchase)
+  35,  // Rakuten TV
+  68,  // Microsoft Store
+  192, // YouTube (rental/purchase)
+  188, // YouTube Premium
+  207, // Redbox
+  258, // Hoopla
+]);
+
+/**
+ * Name patterns to exclude.
+ * Covers rental stores + platform sub-channel add-ons
+ * (e.g. "BET+ Apple TV Channel", "Starz Amazon Channel").
+ */
+export const EXCLUDED_PROVIDER_PATTERNS: RegExp[] = [
+  /itunes/i,
+  /google play/i,
+  /microsoft store/i,
+  /fandango/i,
+  /redbox/i,
+  /\bstore\b/i,
+  /\brent\b/i,
+  // Platform distribution add-on channels
+  /apple tv channel/i,
+  /amazon channel/i,
+  /prime video channel/i,
+  /roku channel/i,
+  /\bchannel$/i,   // bare "Channel" suffix (e.g. "Starz Channel")
+];
+
+/**
+ * Normalize a provider name for deduplication.
+ * Strips tier suffixes ("Basic", "Standard with Ads", etc.) and
+ * platform-distribution suffixes so "Netflix" and "Netflix Basic"
+ * map to the same key.
+ */
+export function normalizeProviderName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s+(apple tv|amazon|prime video|roku).*$/i, '') // strip platform suffix
+    .replace(/[^a-z0-9]/g, '')
+    .replace(/(basic|standard|premium|kids|plus|hd|4k|withadvertisements|withads|ads)$/g, '')
+    .trim();
+}
+
+/**
+ * Returns true if the provider should be excluded (rental store, sub-channel, etc.).
+ */
+export function shouldExcludeProvider(p: RawProvider): boolean {
+  return (
+    EXCLUDED_PROVIDER_IDS.has(p.provider_id) ||
+    EXCLUDED_PROVIDER_PATTERNS.some(re => re.test(p.provider_name))
+  );
+}
+
+/**
+ * Filter and deduplicate a list of raw TMDB providers.
+ * Removes rental/purchase stores, sub-channel add-ons, and duplicate
+ * tier variants of the same service.
+ *
+ * @param providers  Raw TMDB flatrate/subscription providers
+ * @param maxResults Optional hard cap (default: unlimited)
+ */
+export function filterProviders(
+  providers: RawProvider[],
+  maxResults?: number,
+): RawProvider[] {
+  const seen = new Set<string>();
+  const result: RawProvider[] = [];
+
+  for (const p of providers) {
+    if (shouldExcludeProvider(p)) continue;
+    const key = normalizeProviderName(p.provider_name);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(p);
+    if (maxResults !== undefined && result.length >= maxResults) break;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Problem
Provider filtering logic lived in two separate places and had diverged:
- **Filter panel** (`providers/route.ts`): had full exclusion list (IDs + patterns)  
- **Card/title enrichment** (`socket-server/tmdb.ts`): missing the `EXCLUDED_IDS` list and some name patterns → rental stores and sub-channels still appeared on swipe cards

## Fix: `packages/shared` workspace

New `@showmatch/shared` npm workspace package with a single `providerFilter.ts`:
- `EXCLUDED_PROVIDER_IDS` — 10 rental/purchase store IDs  
- `EXCLUDED_PROVIDER_PATTERNS` — regex list (stores, sub-channels, rental keywords)
- `normalizeProviderName()` — dedup key (strips tier suffixes like "Basic", "Standard with Ads")
- `shouldExcludeProvider()` — combine the above checks
- `filterProviders(providers, maxResults?)` — the one function to call

Both apps now import `filterProviders` from `@showmatch/shared`. Future changes need to happen in **one file only**.