### PR TITLE
fix: card stack collapses to zero height (black swipe screen)

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -138,7 +138,7 @@ export default function GamePage() {
         )}
 
         {/* Card Stack */}
-        <div className="flex-1 flex items-center justify-center mt-4 overflow-hidden">
+        <div className="flex-1 flex items-stretch justify-center mt-4 overflow-hidden">
           <CardStack
             cards={titlePool}
             currentIndex={currentCardIndex}


### PR DESCRIPTION
Closes #64

## Root Cause

PR #62 replaced the hardcoded `height: 'min(75vh, 600px)'` on CardStack with `h-full`, but the parent wrapper in the game page uses `items-center`.

In CSS, `height: 100%` on a flex child does **not** resolve to the flex container's computed height when `align-items: center` is set — it falls back to `auto`, which for a container of absolutely-positioned children is **0**. Result: all cards have zero height → black screen.

## Fix

Change `items-center` → `items-stretch` on the wrapper div. CardStack now stretches to the wrapper's flex-1 computed height, the `h-full` chain resolves correctly, and cards fill the available space.

Horizontal centering is preserved by `justify-center` on the wrapper + `mx-auto max-w-[min(90vw,400px)]` on CardStack.