### PR TITLE
fix: game page needs definite height so h-full chain works

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -98,7 +98,7 @@ export default function GamePage() {
   const otherPlayers = room.players.filter(p => p.id !== playerId);
 
   return (
-    <main className="min-h-screen bg-dark flex flex-col overflow-hidden" style={{ touchAction: 'pan-y' }}>
+    <main className="bg-dark flex flex-col overflow-hidden" style={{ height: '100svh', touchAction: 'pan-y' }}>
       <TutorialOverlay onDismiss={() => setShowTutorial(false)} />
       {/* Header */}
       <header className="flex items-center justify-between p-3 border-b border-dark-border">


### PR DESCRIPTION
Closes #66

## Root Cause

`main` had `min-h-screen` (`min-height: 100vh`). CSS only resolves `height: 100%` and distributes `flex-1` free space when the ancestor flex container has a **definite height** (an explicit `height` value, not `min-height`).

With `min-height` only, the flex container's height is auto (content-driven). CardStack and SwipeCard are full of `h-full` / absolutely-positioned elements that contribute zero content height, so the entire chain resolves to 0px → invisible cards.

This is why PR #62's `h-full`-based approach worked in isolation but failed in context, and why the original hardcoded `height: min(75vh, 600px)` (before PR #62) never had this problem — it bypassed the chain entirely.

## Fix

Replace `min-h-screen` with `height: 100svh` (inline style, `svh` for mobile browser compatibility — same unit already used throughout SwipeCard). This gives `main` a definite height, making every `flex-1` and `h-full` below it resolve correctly.