### PR TITLE
fix: h-screen + min-h-0 so card h-full chain resolves

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -98,7 +98,7 @@ export default function GamePage() {
   const otherPlayers = room.players.filter(p => p.id !== playerId);
 
   return (
-    <main className="bg-dark flex flex-col overflow-hidden" style={{ height: '100svh', touchAction: 'pan-y' }}>
+    <main className="h-screen bg-dark flex flex-col overflow-hidden" style={{ touchAction: 'pan-y' }}>
       <TutorialOverlay onDismiss={() => setShowTutorial(false)} />
       {/* Header */}
       <header className="flex items-center justify-between p-3 border-b border-dark-border">
@@ -121,7 +121,7 @@ export default function GamePage() {
         </div>
       </header>
 
-      <div className="flex-1 flex flex-col p-4 max-w-lg mx-auto w-full">
+      <div className="flex-1 min-h-0 flex flex-col p-4 max-w-lg mx-auto w-full">
         {/* Progress */}
         <ProgressBar current={currentCardIndex} total={titlePool.length} />
 
@@ -138,7 +138,7 @@ export default function GamePage() {
         )}
 
         {/* Card Stack */}
-        <div className="flex-1 flex items-stretch justify-center mt-4 overflow-hidden">
+        <div className="flex-1 min-h-0 flex items-stretch justify-center mt-4 overflow-hidden">
           <CardStack
             cards={titlePool}
             currentIndex={currentCardIndex}


### PR DESCRIPTION
Closes #66 (continued)

## What failed before

Previous attempts used `height: 100svh` (not supported on older mobile browsers) and `items-stretch` alone (correct but insufficient). The `h-full` chain in CardStack/SwipeCard was still resolving to 0px.

## Root Cause (complete picture)

Two combined issues:
1. **No definite root height** — `min-height: 100vh` and `height: 100svh` both failed (either semantically wrong or unsupported). Only `height: 100vh` via Tailwind's `h-screen` is definite and universally supported.
2. **`min-height: auto` inflation** — flex items default to `min-height: auto`, which causes flex containers to ignore their `flex-1` allocation and size to content instead. Without `min-h-0` on the flex-col children, the card wrapper's computed height was content-based (= 0 for absolute-positioned cards).

## Fix

- `main`: `h-screen` (definite `height: 100vh`)
- inner flex-col div: `min-h-0`
- card wrapper: `min-h-0`