### PR TITLE
fix: tutorial replay button + duplicate streaming providers

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -117,7 +117,7 @@ export default function GamePage() {
 
   return (
     <main className="bg-dark flex flex-col overflow-hidden" style={{ height: 'var(--game-h, 100vh)', touchAction: 'pan-y' }}>
-      <TutorialOverlay onDismiss={() => setShowTutorial(false)} />
+      <TutorialOverlay onDismiss={() => setShowTutorial(false)} forceShow={showTutorial} />
       {/* Header */}
       <header className="flex items-center justify-between p-3 border-b border-dark-border">
         <Logo size="sm" />

--- a/apps/web/src/components/game/TutorialOverlay.tsx
+++ b/apps/web/src/components/game/TutorialOverlay.tsx
@@ -33,18 +33,29 @@ const STEPS = [
 
 interface TutorialOverlayProps {
   onDismiss: () => void;
+  /** Set to true to force-show the tutorial (e.g. replay button). */
+  forceShow?: boolean;
 }
 
-export default function TutorialOverlay({ onDismiss }: TutorialOverlayProps) {
+export default function TutorialOverlay({ onDismiss, forceShow }: TutorialOverlayProps) {
   const [step, setStep] = useState(0);
   const [visible, setVisible] = useState(false);
 
+  // Show on first visit
   useEffect(() => {
     const seen = localStorage.getItem('showmatch-tutorial-seen');
     if (!seen) {
       setVisible(true);
     }
   }, []);
+
+  // Re-show when parent requests replay
+  useEffect(() => {
+    if (forceShow) {
+      setStep(0);
+      setVisible(true);
+    }
+  }, [forceShow]);
 
   const handleNext = () => {
     if (step >= STEPS.length - 1) {

--- a/packages/shared/src/providerFilter.ts
+++ b/packages/shared/src/providerFilter.ts
@@ -63,7 +63,7 @@ export function normalizeProviderName(name: string): string {
     .toLowerCase()
     .replace(/\s+(apple tv|amazon|prime video|roku).*$/i, '') // strip platform suffix
     .replace(/[^a-z0-9]/g, '')
-    .replace(/(basic|standard|premium|kids|plus|hd|4k|withadvertisements|withads|ads)$/g, '')
+    .replace(/(basic|standard|premium|essential|kids|plus|hd|4k|withadvertisements|withads|adsupported|ads)$/g, '')
     .trim();
 }
 


### PR DESCRIPTION
Closes #70, Closes #71

## Tutorial replay (? button did nothing)

`TutorialOverlay` checks localStorage only **at mount time** (single `useEffect([], [])`). The replay button cleared localStorage and set `showTutorial=true` in the game page, but `showTutorial` was never passed to the overlay — it had no way to re-show itself.

**Fix:** Add `forceShow?: boolean` prop. A second `useEffect([forceShow])` watches for it flipping `true` and resets `step=0` + `visible=true`. Game page wires it via `forceShow={showTutorial}`.

## Duplicate providers (Paramount+ Premium + Essential)

`normalizeProviderName()` stripped `basic | standard | premium | plus | ...` but missed **`essential`**. Result: both tiers got different dedup keys and both appeared on the card.

**Fix:** Added `essential` and `adsupported` to the tier-suffix regex in `packages/shared/src/providerFilter.ts`. Both Paramount+ variants now normalize to `paramount`.