### PR TITLE
fix: filter out titles with no streaming providers

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -47,10 +47,13 @@ export async function fetchDiscoverResults(
 ): Promise<TitleCard[]> {
   const allResults: TitleCard[] = [];
   const poolSize = settings.poolSize === 'all' ? 500 : settings.poolSize;
+  // Fetch 1.5× more raw results to compensate for titles filtered out after
+  // enrichment (theatrical/pre-streaming releases with no flatrate providers).
+  const fetchSize = Math.min(Math.ceil(poolSize * 1.5), 500);
 
   for (const mediaType of settings.mediaTypes) {
     const params = buildDiscoverParams(settings, mediaType);
-    const perType = Math.ceil(poolSize / settings.mediaTypes.length);
+    const perType = Math.ceil(fetchSize / settings.mediaTypes.length);
     const pagesNeeded = Math.min(Math.ceil(perType / 20), 25);
 
     for (let page = 1; page <= pagesNeeded; page++) {
@@ -64,7 +67,7 @@ export async function fetchDiscoverResults(
           allResults.push(mapBasicResult(item, mediaType));
         }
 
-        if (allResults.length >= poolSize) break;
+        if (allResults.length >= fetchSize) break;
         if (page >= data.total_pages) break;
       } catch (err) {
         console.error(`Error fetching page ${page}:`, err);
@@ -73,7 +76,7 @@ export async function fetchDiscoverResults(
     }
   }
 
-  const trimmed = allResults.slice(0, poolSize);
+  const trimmed = allResults.slice(0, fetchSize);
   const total = trimmed.length;
   let done = 0;
 
@@ -91,7 +94,10 @@ export async function fetchDiscoverResults(
     onProgress?.(done, total);
   }
 
-  return enriched;
+  // Drop titles with no streamable providers in the user's region.
+  // These are theatrical/pre-streaming releases that slip through the
+  // TMDB discover filter.  Trim to the original target pool size.
+  return enriched.filter(t => t.providers.length > 0).slice(0, poolSize);
 }
 
 async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard> {


### PR DESCRIPTION
Closes #73

## Problem

Theatrical/pre-streaming titles (e.g. *Project Hail Mary* 2026) appear in the swipe deck with no provider logos. TMDB's discover filter (`with_watch_providers`) isn't fully reliable — these titles are popular enough to surface, but `enrichTitle` finds no flatrate subscription providers for them in the user's region.

## Fix

1. **Fetch 1.5× the target pool size** to build a buffer of raw results — so after filtering we still have enough cards.
2. **Drop titles with `providers.length === 0`** after enrichment (the reliable moment when we know a title's actual streaming availability).
3. **Trim to `poolSize`** to return the original target count.