### PR TITLE
fix: useLayoutEffect + React state for mobile viewport height

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useLayoutEffect, useCallback, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
@@ -18,21 +18,19 @@ import { useSound } from '@/hooks/useSound';
 export default function GamePage() {
   useBeforeUnload();
 
-  // Reliably set the game page height on mobile browsers where 100vh ≠ visible area.
-  // visualViewport.height is the true visible height, accounting for browser chrome.
-  useEffect(() => {
+  // Use visualViewport.height (true visible height on mobile) via React state.
+  // useLayoutEffect fires before the browser paints, so the correct height is
+  // applied on the very first frame — no flash of wrong layout.
+  const [gameHeight, setGameHeight] = useState('100vh');
+  useLayoutEffect(() => {
     const set = () => {
       const h = window.visualViewport?.height ?? window.innerHeight;
-      document.documentElement.style.setProperty('--game-h', `${h}px`);
+      setGameHeight(`${h}px`);
     };
     set();
     const vv = window.visualViewport;
     vv?.addEventListener('resize', set);
-    window.addEventListener('resize', set);
-    return () => {
-      vv?.removeEventListener('resize', set);
-      window.removeEventListener('resize', set);
-    };
+    return () => vv?.removeEventListener('resize', set);
   }, []);
 
   const router = useRouter();
@@ -116,7 +114,7 @@ export default function GamePage() {
   const otherPlayers = room.players.filter(p => p.id !== playerId);
 
   return (
-    <main className="bg-dark flex flex-col overflow-hidden" style={{ height: 'var(--game-h, 100vh)', touchAction: 'pan-y' }}>
+    <main className="bg-dark flex flex-col overflow-hidden" style={{ height: gameHeight, touchAction: 'pan-y' }}>
       <TutorialOverlay onDismiss={() => setShowTutorial(false)} forceShow={showTutorial} />
       {/* Header */}
       <header className="flex items-center justify-between p-3 border-b border-dark-border">


### PR DESCRIPTION
## Root cause

`useEffect` runs *after* the browser paints the first frame. On mobile, that first frame used `100vh` (the fallback), which is the wrong height. The correct `visualViewport.height` only kicked in on the *second* render, but by then the flex chain had already calculated wrong sizes and the browser may not have fully recalculated layout.

## Fix

- **`useLayoutEffect`** — runs synchronously after DOM mutations, *before* the browser paints. The correct height is applied on frame 0.
- **React state instead of CSS custom property** — `setState` guarantees a synchronous re-render pipeline. Some mobile browsers don't immediately repaint when a CSS custom property changes; going through React's render is bulletproof.