### PR TITLE
fix: verify room exists before showing name picker

### DIFF
--- a/apps/socket-server/src/handlers/roomHandler.ts
+++ b/apps/socket-server/src/handlers/roomHandler.ts
@@ -34,6 +34,19 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
     console.log(`${playerName} joined room ${code}`);
   });
 
+  socket.on('checkRoom', (code: string, callback: Function) => {
+    const room = roomManager.getRoom(code?.toUpperCase());
+    if (!room) {
+      callback({ error: 'Room not found' });
+      return;
+    }
+    if (room.status !== 'lobby') {
+      callback({ error: 'Game already in progress' });
+      return;
+    }
+    callback({ status: room.status, playerCount: room.players.length });
+  });
+
   socket.on('leaveRoom', (payload?: { playerId?: string }) => {
     // Support playerId fallback so this works even after a socket reconnect
     const room = roomManager.getRoomBySocket(socket.id)

--- a/apps/web/src/app/join/[code]/page.tsx
+++ b/apps/web/src/app/join/[code]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { useSocket } from '@/hooks/useSocket';
@@ -24,6 +24,29 @@ export default function JoinPage() {
   const [name, setName] = useState(randomName());
   const [error, setError] = useState<string | null>(null);
   const [joining, setJoining] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  // Verify the room exists before showing the name picker.
+  useEffect(() => {
+    const doCheck = () => {
+      socket.emit('checkRoom', code, (response: any) => {
+        if ('error' in response) {
+          sessionStorage.setItem('showmatch-toast', response.error);
+          router.replace('/');
+        } else {
+          setChecking(false);
+        }
+      });
+    };
+
+    if (socket.connected) {
+      doCheck();
+    } else {
+      socket.once('connect', doCheck);
+      socket.connect();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleJoin = () => {
     if (!name.trim() || joining) return;
@@ -50,6 +73,19 @@ export default function JoinPage() {
       socket.connect();
     }
   };
+
+  if (checking) {
+    return (
+      <main className="min-h-screen bg-dark flex flex-col">
+        <header className="flex items-center p-4 border-b border-dark-border">
+          <Logo size="sm" />
+        </header>
+        <div className="flex-1 flex items-center justify-center text-gray-500">
+          Checking room…
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="min-h-screen bg-dark">


### PR DESCRIPTION
Closes #76

## Problem
Entering any 5-character code on the landing page navigated to `/join/[code]` immediately — the name picker showed for non-existent rooms. The error only appeared after the user filled in their name and clicked Join.

## Fix
**Server:** New `checkRoom` socket event — returns `{ error }` if the room doesn't exist or the game is already in progress; returns `{ status, playerCount }` if OK.

**Join page:** On mount, emits `checkRoom` before showing the name picker form:
- Displays "Checking room…" while waiting
- Invalid code → `router.replace('/')` + session-storage toast (shown on landing page)
- Valid code → name picker form becomes visible