### PR TITLE
feat: superlike swipe-up hint overlay

### DIFF
--- a/apps/web/src/components/game/CardOverlay.tsx
+++ b/apps/web/src/components/game/CardOverlay.tsx
@@ -5,9 +5,10 @@ import { motion, type MotionValue } from 'framer-motion';
 interface CardOverlayProps {
   likeOpacity: MotionValue<number>;
   nopeOpacity: MotionValue<number>;
+  superLikeOpacity?: MotionValue<number>;
 }
 
-export default function CardOverlay({ likeOpacity, nopeOpacity }: CardOverlayProps) {
+export default function CardOverlay({ likeOpacity, nopeOpacity, superLikeOpacity }: CardOverlayProps) {
   return (
     <>
       {/* WANT stamp */}
@@ -29,6 +30,18 @@ export default function CardOverlay({ likeOpacity, nopeOpacity }: CardOverlayPro
           NOPE
         </div>
       </motion.div>
+
+      {/* SUPER stamp — only when superlike not yet used */}
+      {superLikeOpacity && (
+        <motion.div
+          className="absolute inset-0 z-20 flex items-end justify-center pb-8 pointer-events-none"
+          style={{ opacity: superLikeOpacity }}
+        >
+          <div className="border-4 border-yellow-400 text-yellow-400 px-8 py-3 rounded-xl text-4xl font-extrabold">
+            ⭐ SUPER
+          </div>
+        </motion.div>
+      )}
     </>
   );
 }

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -34,8 +34,9 @@ export default function SwipeCard({
   const x = useMotionValue(0);
   const y = useMotionValue(0);
   const rotate = useTransform(x, [-250, 0, 250], [-18, 0, 18]);
-  const likeOpacity  = useTransform(x, [20, 120], [0, 1]);
-  const nopeOpacity  = useTransform(x, [-120, -20], [1, 0]);
+  const likeOpacity       = useTransform(x, [20, 120], [0, 1]);
+  const nopeOpacity       = useTransform(x, [-120, -20], [1, 0]);
+  const superLikeOpacity  = useTransform(y, [-120, -20], [1, 0]);
   const decisionRef = useRef<'like' | 'pass' | 'superlike'>('pass');
 
   const scale = 1 - stackIndex * 0.05;
@@ -108,7 +109,13 @@ export default function SwipeCard({
         onClick={handleTap}
       >
         {/* Overlay stamps */}
-        {isTop && <CardOverlay likeOpacity={likeOpacity} nopeOpacity={nopeOpacity} />}
+        {isTop && (
+          <CardOverlay
+            likeOpacity={likeOpacity}
+            nopeOpacity={nopeOpacity}
+            superLikeOpacity={superLikeUsed ? undefined : superLikeOpacity}
+          />
+        )}
 
         {/* Card faces wrapper (3D perspective) */}
         <div className="h-full" style={{ perspective: 1200 }}>


### PR DESCRIPTION
Mirrors the WANT/NOPE hint stamps for upward swipe.

- `superLikeOpacity` motion value via `useTransform(y, [-120, -20], [1, 0])` in SwipeCard
- Passed to CardOverlay as optional prop (omitted when superlike already used)
- Gold ⭐ SUPER stamp anchored at card bottom — appears as the card slides up
- Not shown if superlike is already spent