### PR TITLE
fix: socket reconnect recovery — rejoin room or redirect home

### DIFF
--- a/apps/socket-server/src/handlers/roomHandler.ts
+++ b/apps/socket-server/src/handlers/roomHandler.ts
@@ -34,6 +34,19 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
     console.log(`${playerName} joined room ${code}`);
   });
 
+  socket.on('rejoinGame', ({ code, displayName }: { code: string; displayName: string }) => {
+    const result = roomManager.rejoinPlayer(code?.toUpperCase(), displayName, socket.id);
+    if (!result) {
+      // Room gone (server restart) or player not found — send them home
+      socket.emit('roomClosed', 'Connection lost. The room no longer exists.');
+      return;
+    }
+    const { room } = result;
+    socket.join(room.code);
+    console.log(`[rejoinGame] ${displayName} re-attached to room ${room.code}`);
+    socket.emit('gameRejoined', roomManager.serializeRoom(room), room.titlePool);
+  });
+
   socket.on('checkRoom', (code: string, callback: Function) => {
     const room = roomManager.getRoom(code?.toUpperCase());
     if (!room) {

--- a/apps/socket-server/src/state/RoomManager.ts
+++ b/apps/socket-server/src/state/RoomManager.ts
@@ -85,6 +85,51 @@ class RoomManager {
     return { room };
   }
 
+  /**
+   * Re-attach a socket to an existing in-game player.
+   * Works regardless of current connected state — handles both brief
+   * disconnects and server-restart re-joins.
+   */
+  rejoinPlayer(code: string, displayName: string, newSocketId: string): { room: Room; player: Player } | null {
+    const room = this.rooms.get(code);
+    if (!room) return null;
+
+    const player = room.players.find(p => p.displayName === displayName);
+    if (!player) return null;
+
+    const oldSocketId = player.id;
+
+    // Cancel any pending disconnect timer
+    const timerKey = `${code}:${oldSocketId}`;
+    const timer = this.disconnectTimers.get(timerKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.disconnectTimers.delete(timerKey);
+    }
+
+    // Migrate swipes / rankings keyed by old socket ID
+    const oldSwipes = room.swipes.get(oldSocketId);
+    if (oldSwipes) {
+      room.swipes.set(newSocketId, oldSwipes);
+      room.swipes.delete(oldSocketId);
+    }
+    const oldRankings = room.rankings.get(oldSocketId);
+    if (oldRankings) {
+      room.rankings.set(newSocketId, oldRankings);
+      room.rankings.delete(oldSocketId);
+    }
+
+    // Remap socket lookups
+    this.socketToRoom.delete(oldSocketId);
+    this.socketToPlayer.delete(oldSocketId);
+    player.id = newSocketId;
+    player.connected = true;
+    this.socketToRoom.set(newSocketId, code);
+    this.socketToPlayer.set(newSocketId, newSocketId);
+
+    return { room, player };
+  }
+
   reconnectPlayer(code: string, playerName: string, newSocketId: string): { room: Room; player: Player } | null {
     const room = this.rooms.get(code);
     if (!room) return null;

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -9,10 +9,28 @@ import type { Socket } from 'socket.io-client';
 export function useSocket() {
   const socketRef = useRef<Socket | null>(null);
   const store = useGameStore();
+  // Track whether this socket has connected at least once so we can
+  // distinguish a reconnect (true) from the initial connection (false).
+  const everConnectedRef = useRef(false);
 
   useEffect(() => {
     const socket = connectSocket();
     socketRef.current = socket;
+
+    // On every (re)connect: if we were already connected before, try to
+    // re-attach to the room.  Handles both brief disconnects and full
+    // server restarts (server responds with roomClosed if room is gone).
+    socket.on('connect', () => {
+      if (!everConnectedRef.current) {
+        everConnectedRef.current = true;
+        return; // initial connect — nothing to rejoin
+      }
+      const { room, playerId } = useGameStore.getState();
+      if (!room) return;
+      const me = room.players.find(p => p.id === playerId);
+      if (!me) return;
+      socket.emit('rejoinGame', { code: room.code, displayName: me.displayName });
+    });
 
     socket.on('playerJoined', (player) => {
       store.addPlayer(player);
@@ -76,6 +94,12 @@ export function useSocket() {
       store.setRoom(room);
     });
 
+    (socket as any).on('gameRejoined', (room: any) => {
+      // Successfully re-attached to existing room after reconnect.
+      // Update room state; keep client-side progress (currentCardIndex) intact.
+      store.setRoom(room);
+    });
+
     socket.on('roomClosed', (reason) => {
       store.reset();
       if (typeof window !== 'undefined') {
@@ -85,6 +109,7 @@ export function useSocket() {
     });
 
     return () => {
+      socket.off('connect');
       socket.off('playerJoined');
       socket.off('playerLeft');
       socket.off('settingsUpdated');
@@ -99,6 +124,7 @@ export function useSocket() {
       (socket as any).off('wildcardCandidates');
       (socket as any).off('roomReset');
       (socket as any).off('loadingProgress');
+      (socket as any).off('gameRejoined');
     };
   }, []);
 


### PR DESCRIPTION
## Root Cause

When the socket auto-reconnects (server restart or network blip), the new `socket.id` isn't in `socketToRoom`. `submitSwipe` returns early on every swipe. The server never marks the player finished. `allPlayersFinished` never fires. Players stuck forever on 'Waiting for others…'.

## Changes

**`RoomManager.rejoinPlayer()`**
Re-attaches a new socket to its existing player entry: migrates swipes/rankings from old socket ID, cancels pending disconnect timer, remaps all socket→room/player lookups.

**`roomHandler` — `rejoinGame` event**
- Room not found (server restarted) → `roomClosed` → client redirects to `/`
- Room found → `rejoinPlayer` + re-join Socket.io room + emit `gameRejoined`

**`useSocket`**
- Tracks `everConnectedRef`; on every `connect` event after the first, emits `rejoinGame` with `{ code, displayName }` if a room exists in the store
- Handles `gameRejoined`: updates room state, preserves client-side `currentCardIndex`