### PR TITLE
fix: only filter provider-less titles when providers were selected

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -94,10 +94,12 @@ export async function fetchDiscoverResults(
     onProgress?.(done, total);
   }
 
-  // Drop titles with no streamable providers in the user's region.
-  // These are theatrical/pre-streaming releases that slip through the
-  // TMDB discover filter.  Trim to the original target pool size.
-  return enriched.filter(t => t.providers.length > 0).slice(0, poolSize);
+  // Only drop provider-less titles when the user actually filtered by provider.
+  // Without a provider filter, theatrical/un-streamed titles are fair game.
+  const filtered = settings.providers.length > 0
+    ? enriched.filter(t => t.providers.length > 0)
+    : enriched;
+  return filtered.slice(0, poolSize);
 }
 
 async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard> {


### PR DESCRIPTION
Previously, titles with no streaming providers were always dropped from the pool, even when the user hadn't selected any specific services. This unnecessarily excluded theatrical/newer titles from unfiltered games.

**New behaviour:** provider filter (no providers = no filtering) is only applied when `settings.providers.length > 0`. The 1.5× fetch buffer remains active for the filtered case.