### PR TITLE
fix: show roomClosed toast when host exits mid-game

### DIFF
--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -101,7 +101,11 @@ export function useSocket() {
     });
 
     socket.on('roomClosed', (reason) => {
-      store.reset();
+      // Don't call store.reset() here — it nullifies `room` which triggers the
+      // game page's guard effect to do a SPA navigation that races with our
+      // window.location.href below and can eat the toast from sessionStorage.
+      // A full-page reload (window.location.href) already wipes all in-memory
+      // state, so the reset is redundant anyway.
       if (typeof window !== 'undefined') {
         sessionStorage.setItem('showmatch-toast', reason);
         window.location.href = '/';


### PR DESCRIPTION
**Bug:** when the host left an ongoing game, the other players were silently redirected to the home page with no notification. The 'End Game' button on the results page worked correctly, but mid-game exits didn't.

**Root cause:** the `roomClosed` socket handler called `store.reset()` before setting the sessionStorage toast. This nullified `room`, which triggered the game page's guard effect (`if (!room) router.push('/')`) as a competing SPA navigation. The SPA navigation raced with `window.location.href = '/'`: the first to mount the home page would read + remove the toast from sessionStorage, leaving the second mount empty — no visible toast.

**Fix:** remove `store.reset()` from the handler. `window.location.href` causes a full page reload which already wipes all in-memory Zustand state. No SPA guard fires, full reload lands on home page, toast is shown as expected.