### PR TITLE
fix: drag handle for ranking list — fixes mobile scroll conflict

### DIFF
--- a/apps/web/src/components/results/RankingBoard.tsx
+++ b/apps/web/src/components/results/RankingBoard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Reorder, motion } from 'framer-motion';
+import { Reorder, motion, useDragControls } from 'framer-motion';
 import type { TitleCard } from '@/types/game';
 import Button from '@/components/ui/Button';
 
@@ -9,6 +9,57 @@ interface RankingBoardProps {
   titles: TitleCard[];
   onSubmit: (rankings: Array<{ tmdbId: number; rank: number }>) => void;
   submitted: boolean;
+}
+
+/** Single draggable row — needs its own component so we can call useDragControls per item. */
+function DraggableItem({ item, index }: { item: TitleCard; index: number }) {
+  const dragControls = useDragControls();
+
+  return (
+    <Reorder.Item
+      value={item}
+      dragListener={false}
+      dragControls={dragControls}
+    >
+      <motion.div
+        className="flex items-center gap-3 bg-dark-card rounded-xl p-3 mb-2 border border-dark-border"
+        whileDrag={{ scale: 1.02, boxShadow: '0 0 20px rgba(229,9,20,0.3)' }}
+        layout
+      >
+        <span className="text-lg font-bold text-primary w-8 text-center shrink-0">
+          {index + 1}
+        </span>
+
+        {item.posterPath && (
+          <img
+            src={item.posterPath}
+            alt={item.title}
+            className="w-10 h-14 rounded object-cover shrink-0"
+          />
+        )}
+
+        <div className="flex-1 min-w-0">
+          <p className="font-medium truncate" title={item.title}>{item.title}</p>
+          <p className="text-xs text-gray-500">{item.year} &middot; &#9733; {item.voteAverage.toFixed(1)}</p>
+        </div>
+
+        {/* Drag handle — only this area initiates drag; rest of card is scroll-friendly */}
+        <div
+          className="shrink-0 flex items-center justify-center w-10 h-10 rounded-lg
+                     text-gray-500 active:text-primary
+                     cursor-grab active:cursor-grabbing select-none"
+          style={{ touchAction: 'none' }}
+          onPointerDown={(e) => dragControls.start(e)}
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor">
+            <rect x="2" y="3" width="14" height="2" rx="1" />
+            <rect x="2" y="8" width="14" height="2" rx="1" />
+            <rect x="2" y="13" width="14" height="2" rx="1" />
+          </svg>
+        </div>
+      </motion.div>
+    </Reorder.Item>
+  );
 }
 
 export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoardProps) {
@@ -24,9 +75,14 @@ export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoa
 
   return (
     <div className="space-y-4">
-      <h2 className="text-xl font-bold text-center">
-        You agreed on {titles.length} titles! Rank them.
-      </h2>
+      <div className="text-center">
+        <h2 className="text-xl font-bold">
+          You agreed on {titles.length} titles! Rank them.
+        </h2>
+        {!submitted && (
+          <p className="text-xs text-gray-500 mt-1">Hold the <span className="text-gray-400">≡</span> handle to drag</p>
+        )}
+      </div>
 
       {submitted ? (
         // Locked static list after submission
@@ -36,39 +92,22 @@ export default function RankingBoard({ titles, onSubmit, submitted }: RankingBoa
               key={item.tmdbId}
               className="flex items-center gap-3 bg-dark-card rounded-xl p-3 mb-2 border border-dark-border opacity-60"
             >
-              <span className="text-lg font-bold text-primary w-8 text-center">{index + 1}</span>
+              <span className="text-lg font-bold text-primary w-8 text-center shrink-0">{index + 1}</span>
               {item.posterPath && (
-                <img src={item.posterPath} alt={item.title} className="w-10 h-14 rounded object-cover" />
+                <img src={item.posterPath} alt={item.title} className="w-10 h-14 rounded object-cover shrink-0" />
               )}
               <div className="flex-1 min-w-0">
                 <p className="font-medium truncate" title={item.title}>{item.title}</p>
                 <p className="text-xs text-gray-500">{item.year} &middot; &#9733; {item.voteAverage.toFixed(1)}</p>
               </div>
-              <span className="text-green-400 text-lg">✓</span>
+              <span className="text-green-400 text-lg shrink-0">✓</span>
             </div>
           ))}
         </div>
       ) : (
-        // Draggable list before submission
         <Reorder.Group axis="y" values={items} onReorder={setItems}>
           {items.map((item, index) => (
-            <Reorder.Item key={item.tmdbId} value={item}>
-              <motion.div
-                className="flex items-center gap-3 bg-dark-card rounded-xl p-3 mb-2 border border-dark-border cursor-grab active:cursor-grabbing"
-                whileDrag={{ scale: 1.02, boxShadow: '0 0 20px rgba(229,9,20,0.3)' }}
-                layout
-              >
-                <span className="text-lg font-bold text-primary w-8 text-center">{index + 1}</span>
-                {item.posterPath && (
-                  <img src={item.posterPath} alt={item.title} className="w-10 h-14 rounded object-cover" />
-                )}
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium truncate" title={item.title}>{item.title}</p>
-                  <p className="text-xs text-gray-500">{item.year} &middot; &#9733; {item.voteAverage.toFixed(1)}</p>
-                </div>
-                <div className="text-gray-600 text-xl cursor-grab">&#9776;</div>
-              </motion.div>
-            </Reorder.Item>
+            <DraggableItem key={item.tmdbId} item={item} index={index} />
           ))}
         </Reorder.Group>
       )}


### PR DESCRIPTION
**Problem:** the entire ranking card was the drag target, so any touch on the list started a drag instead of scrolling. Near-unusable on mobile.

**Fix:** `useDragControls` + `dragListener={false}` on `Reorder.Item` — drag only starts when the user presses the ≡ handle on the right edge. `touchAction: none` scoped only to that handle element.

- Extracted `DraggableItem` sub-component (required since `useDragControls` is a hook and can't be called inside `.map()`)
- Added a small hint below the title: *'Hold the ≡ handle to drag'*
- Rest of the card and the page scrolls naturally on mobile