### PR TITLE
feat: shorter confetti + victory sound on winner reveal

### DIFF
--- a/apps/web/src/components/results/Confetti.tsx
+++ b/apps/web/src/components/results/Confetti.tsx
@@ -6,18 +6,18 @@ export default function Confetti() {
   useEffect(() => {
     import('canvas-confetti').then(mod => {
       const confetti = mod.default;
-      const duration = 3500;
+      const duration = 1500;
       const end = Date.now() + duration;
 
-      // Burst from both sides — more particles, useWorker:false for mobile compat
+      // Burst from both sides — useWorker:false for mobile compat
       // (cast to any to bypass outdated type definitions)
       const fire = (opts: object) =>
         (confetti as any)({
-          particleCount: 6,
-          spread: 60,
-          ticks: 200,
-          gravity: 1.2,
-          scalar: 1.1,
+          particleCount: 4,
+          spread: 55,
+          ticks: 150,
+          gravity: 1.4,
+          scalar: 1.0,
           colors: ['#e50914', '#ffd700', '#00c853', '#ffffff', '#ff69b4'],
           disableForReducedMotion: true,
           useWorker: false,
@@ -30,10 +30,10 @@ export default function Confetti() {
         if (Date.now() < end) requestAnimationFrame(frame);
       };
 
-      // Initial big burst
+      // Initial burst (lighter than before)
       (confetti as any)({
-        particleCount: 80,
-        spread: 100,
+        particleCount: 50,
+        spread: 90,
         origin: { y: 0.5 },
         colors: ['#e50914', '#ffd700', '#00c853'],
         disableForReducedMotion: true,

--- a/apps/web/src/components/results/ResultReveal.tsx
+++ b/apps/web/src/components/results/ResultReveal.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import type { TitleCard } from '@/types/game';
 import Confetti from './Confetti';
 import StreamingLogos from '@/components/game/StreamingLogos';
+import { playSound } from '@/lib/sounds';
 
 interface ResultRevealProps {
   winner: TitleCard;
@@ -25,6 +26,15 @@ export default function ResultReveal({ winner, skipCountdown = false }: ResultRe
       setRevealed(true);
     }
   }, [countdown, skipCountdown]);
+
+  // Play victory sound when the winner card animates in.
+  // Guard with !skipCountdown: firstMatch path already plays it via useSocket.
+  useEffect(() => {
+    if (revealed && !skipCountdown) {
+      playSound('victory');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealed]);
 
   return (
     <div className="text-center">


### PR DESCRIPTION
- **Confetti**: 3.5 s → 1.5 s duration, lighter particle counts — still celebratory but doesn't overstay its welcome
- **Sound**: `victory` plays when the 3-2-1 countdown hits zero and the winner card springs in. Skipped for the `firstMatch` path (already plays there via `useSocket`)