### PR TITLE
feat: UX polish v2 — bugs, better cards, sticky results, keyboard shortcuts

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -145,8 +145,8 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
       }));
     }
 
-    // External IDs + OMDB (movies only)
-    if (type === 'movie' && externalRes.status === 'fulfilled' && externalRes.value.ok) {
+    // External IDs + OMDB (movies and TV — OMDB supports both)
+    if (externalRes.status === 'fulfilled' && externalRes.value.ok) {
       const external = await externalRes.value.json();
       if (external.imdb_id && getOmdbKey()) {
         try {

--- a/apps/web/src/app/api/tmdb/providers/route.ts
+++ b/apps/web/src/app/api/tmdb/providers/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
 
   // Sort by priority, then run through the shared filter (excludes stores,
   // sub-channels, deduplicates tier variants) with a hard cap of 30.
-  const sorted = [...byId.values()].sort((a, b) => a.display_priority - b.display_priority);
+  const sorted = Array.from(byId.values()).sort((a, b) => a.display_priority - b.display_priority);
   const filtered = filterProviders(sorted, 30);
 
   return NextResponse.json(

--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -91,7 +91,7 @@ export default function CreatePage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
         >
-          <Logo size="md" />
+          <Logo size="sm" />
 
           <div className="w-full text-center">
             <h2 className="text-xl font-bold mb-1">What's your name?</h2>

--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -6,7 +6,6 @@ import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
 import CardStack from '@/components/game/CardStack';
 import SwipeButtons from '@/components/game/SwipeButtons';
-import UndoButton from '@/components/game/UndoButton';
 import ProgressBar from '@/components/game/ProgressBar';
 import TimerBar from '@/components/game/TimerBar';
 import PlayerAvatar from '@/components/lobby/PlayerAvatar';
@@ -107,6 +106,21 @@ export default function GamePage() {
     handleSwipe('pass');
   }, [handleSwipe]);
 
+  // Keyboard shortcuts: ← pass, → like, ↑ superlike
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!room || !titlePool.length) return;
+      const finished = currentCardIndex >= titlePool.length;
+      const player = room.players.find(p => p.id === playerId);
+      if (finished || pendingDecision) return;
+      if (e.key === 'ArrowLeft')  setPendingDecision('pass');
+      if (e.key === 'ArrowRight') setPendingDecision('like');
+      if (e.key === 'ArrowUp' && !player?.superLikeUsed) setPendingDecision('superlike');
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [room, titlePool, currentCardIndex, pendingDecision, playerId]);
+
   if (!room || !titlePool.length) return null;
 
   const isFinished = currentCardIndex >= titlePool.length;
@@ -162,21 +176,22 @@ export default function GamePage() {
             superLikeUsed={me?.superLikeUsed ?? false}
             pendingDecision={pendingDecision}
             onPendingConsumed={() => setPendingDecision(null)}
+            otherPlayers={otherPlayers}
+            totalCards={titlePool.length}
           />
         </div>
 
         {/* Buttons */}
         {!isFinished && (
-          <div className="flex items-center justify-center gap-4">
-            <UndoButton onClick={handleUndo} disabled={!canUndo} />
-            <SwipeButtons
-              onPass={() => setPendingDecision('pass')}
-              onLike={() => setPendingDecision('like')}
-              onSuperLike={() => setPendingDecision('superlike')}
-              superLikeUsed={me?.superLikeUsed ?? false}
-              disabled={isFinished || !!pendingDecision}
-            />
-          </div>
+          <SwipeButtons
+            onPass={() => setPendingDecision('pass')}
+            onLike={() => setPendingDecision('like')}
+            onSuperLike={() => setPendingDecision('superlike')}
+            onUndo={handleUndo}
+            canUndo={canUndo}
+            superLikeUsed={me?.superLikeUsed ?? false}
+            disabled={isFinished || !!pendingDecision}
+          />
         )}
       </div>
     </main>

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -65,6 +65,9 @@ export default function LobbyPage() {
           <div className="mt-2 flex justify-center">
             <ShareButton code={room.code} />
           </div>
+          {connectedCount < 2 && (
+            <p className="mt-2 text-xs text-gray-600">Share this code with friends to invite them</p>
+          )}
         </motion.div>
 
         {/* Players */}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -58,7 +58,8 @@ export default function Home() {
       <AnimatePresence>
         {toast && (
           <motion.div
-            className="fixed top-4 left-1/2 -translate-x-1/2 bg-dark-card border border-dark-border px-6 py-3 rounded-xl text-sm z-50 whitespace-nowrap"
+            className="fixed left-1/2 -translate-x-1/2 bg-dark-card border border-dark-border px-6 py-3 rounded-xl text-sm z-50 whitespace-nowrap"
+            style={{ top: 'max(1rem, env(safe-area-inset-top))' }}
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -102,7 +102,7 @@ export default function ResultsPage() {
   const waitingForResults = gameOver && !winner && !isRanking && !noMatches;
 
   return (
-    <main className="min-h-screen bg-dark">
+    <main className="min-h-screen bg-dark pb-36">
       <header className="flex items-center p-4 border-b border-dark-border">
         <Logo size="sm" />
       </header>
@@ -154,45 +154,33 @@ export default function ResultsPage() {
               skipCountdown={isFirstMatch || matchedTitles.length === 1}
             />
 
-            <div className="mt-8">
+            {/* Watch Now — streaming links */}
+            {winner.providers && winner.providers.length > 0 && (
+              <div className="text-center space-y-2">
+                <p className="text-xs text-gray-500 uppercase tracking-widest">Available on</p>
+                <div className="flex flex-wrap justify-center gap-2">
+                  {winner.providers.map(p => (
+                    <a
+                      key={p.id}
+                      href={`https://www.justwatch.com/search?q=${encodeURIComponent(winner.title)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1.5 bg-dark-surface border border-dark-border rounded-full px-3 py-1.5 text-sm hover:border-primary transition-colors"
+                    >
+                      <img src={p.logoPath} alt={p.name} className="w-5 h-5 rounded" />
+                      {p.name}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="mt-4">
               <SwipeReveal reveals={swipeReveal} />
             </div>
 
             <div className="mt-6">
               <GameStats stats={gameStats} />
-            </div>
-
-            {/* Action buttons */}
-            <div className="mt-8 rounded-2xl bg-dark-card border border-dark-border p-4 space-y-3">
-              {/* Share — always visible */}
-              <button
-                onClick={handleShare}
-                className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-dark-border bg-dark-surface hover:bg-dark-border transition-colors text-white font-semibold text-base active:scale-95"
-              >
-                <span className="text-lg">{shareCopied ? '✓' : '📤'}</span>
-                {shareCopied ? 'Copied to clipboard!' : 'Share Result'}
-              </button>
-
-              {/* Creator-only controls */}
-              {isCreator && (
-                <>
-                  <button
-                    onClick={handlePlayAgain}
-                    className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-primary hover:bg-primary-dark transition-colors text-white font-semibold text-base active:scale-95"
-                  >
-                    <span className="text-lg">🔄</span>
-                    Play Again
-                  </button>
-
-                  <button
-                    onClick={handleEndGame}
-                    className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-red-900/40 bg-red-950/30 hover:bg-red-950/60 transition-colors text-red-400 font-semibold text-base active:scale-95"
-                  >
-                    <span className="text-lg">🚪</span>
-                    End Game
-                  </button>
-                </>
-              )}
             </div>
           </>
         )}
@@ -201,27 +189,43 @@ export default function ResultsPage() {
         {noMatches && (
           <div className="mt-6 space-y-3">
             <p className="text-sm text-gray-500 text-center">Try selecting more genres or lowering the rating threshold</p>
-            {isCreator && (
-              <div className="rounded-2xl bg-dark-card border border-dark-border p-4 space-y-3">
-                <button
-                  onClick={handlePlayAgain}
-                  className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-primary hover:bg-primary-dark transition-colors text-white font-semibold text-base active:scale-95"
-                >
-                  <span className="text-lg">🔄</span>
-                  Play Again
-                </button>
-                <button
-                  onClick={handleEndGame}
-                  className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-red-900/40 bg-red-950/30 hover:bg-red-950/60 transition-colors text-red-400 font-semibold text-base active:scale-95"
-                >
-                  <span className="text-lg">🚪</span>
-                  End Game
-                </button>
-              </div>
-            )}
+{/* action buttons in sticky footer */}
           </div>
         )}
       </div>
+
+      {/* Sticky footer — always visible once game is over */}
+      {(winner || noMatches) && (
+        <div className="fixed bottom-0 left-0 right-0 z-10 bg-dark/90 backdrop-blur-sm border-t border-dark-border">
+          <div className="max-w-lg mx-auto p-3 flex gap-2">
+            <button
+              onClick={handleShare}
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-dark-border bg-dark-surface hover:bg-dark-border transition-colors text-white font-semibold text-sm active:scale-95"
+            >
+              <span>{shareCopied ? '✓' : '📤'}</span>
+              {shareCopied ? 'Copied!' : 'Share'}
+            </button>
+
+            {isCreator && (
+              <>
+                <button
+                  onClick={handlePlayAgain}
+                  className="flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl bg-primary hover:bg-primary/90 transition-colors text-white font-semibold text-sm active:scale-95"
+                >
+                  <span>🔄</span> Play Again
+                </button>
+                <button
+                  onClick={handleEndGame}
+                  className="flex items-center justify-center px-4 py-3 rounded-xl border border-red-900/40 bg-red-950/30 hover:bg-red-950/60 transition-colors text-red-400 text-sm active:scale-95"
+                  title="End Game"
+                >
+                  🚪
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/apps/web/src/components/game/CardStack.tsx
+++ b/apps/web/src/components/game/CardStack.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import type { TitleCard } from '@/types/game';
+import type { Player } from '@/types/game';
 import SwipeCard from './SwipeCard';
 
 interface CardStackProps {
@@ -11,22 +12,54 @@ interface CardStackProps {
   superLikeUsed?: boolean;
   pendingDecision?: 'like' | 'pass' | 'superlike' | null;
   onPendingConsumed?: () => void;
+  /** Other players — shown in the "All done" waiting state */
+  otherPlayers?: Player[];
+  totalCards?: number;
 }
 
 export default function CardStack({
   cards, currentIndex, onSwipe,
   superLikeUsed = false,
   pendingDecision, onPendingConsumed,
+  otherPlayers = [], totalCards,
 }: CardStackProps) {
   if (currentIndex >= cards.length) {
+    const total = totalCards ?? cards.length;
     return (
-      <div className="flex items-center justify-center h-[60vh] text-center">
+      <div className="flex items-center justify-center h-full text-center px-6">
         <motion.div
           initial={{ opacity: 0, scale: 0.9 }}
           animate={{ opacity: 1, scale: 1 }}
+          className="space-y-6"
         >
-          <p className="text-2xl font-bold mb-2">✅ All done!</p>
-          <p className="text-gray-400">Waiting for others to finish…</p>
+          <p className="text-2xl font-bold">✅ All done!</p>
+          {otherPlayers.length > 0 ? (
+            <div className="space-y-3">
+              {otherPlayers.filter(p => p.connected).map(p => {
+                const pct = total > 0 ? Math.min(100, Math.round((p.progress / total) * 100)) : 0;
+                const done = p.progress >= total;
+                return (
+                  <div key={p.id} className="text-left">
+                    <div className="flex justify-between text-sm mb-1">
+                      <span className="text-gray-300">{p.displayName}</span>
+                      <span className={done ? 'text-accent-green font-medium' : 'text-gray-500'}>
+                        {done ? '✓ Done' : `${pct}%`}
+                      </span>
+                    </div>
+                    <div className="h-1.5 bg-dark-border rounded-full overflow-hidden">
+                      <motion.div
+                        className={`h-full rounded-full ${done ? 'bg-accent-green' : 'bg-primary'}`}
+                        animate={{ width: `${pct}%` }}
+                        transition={{ type: 'spring', stiffness: 80 }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-gray-400">Waiting for others to finish…</p>
+          )}
         </motion.div>
       </div>
     );

--- a/apps/web/src/components/game/ProgressBar.tsx
+++ b/apps/web/src/components/game/ProgressBar.tsx
@@ -9,13 +9,10 @@ interface ProgressBarProps {
 
 export default function ProgressBar({ current, total }: ProgressBarProps) {
   const pct = total > 0 ? Math.min(100, (current / total) * 100) : 0;
+  const remaining = Math.max(0, total - current);
 
   return (
     <div className="w-full">
-      <div className="flex justify-between text-xs text-gray-500 mb-1">
-        <span>{current} / {total}</span>
-        <span>{Math.round(pct)}%</span>
-      </div>
       <div className="h-1.5 bg-dark-border rounded-full overflow-hidden">
         <motion.div
           className="h-full bg-primary rounded-full"
@@ -23,6 +20,9 @@ export default function ProgressBar({ current, total }: ProgressBarProps) {
           transition={{ type: 'spring', stiffness: 100 }}
         />
       </div>
+      {remaining > 0 && (
+        <p className="text-right text-xs text-gray-600 mt-0.5">{remaining} left</p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/game/SwipeButtons.tsx
+++ b/apps/web/src/components/game/SwipeButtons.tsx
@@ -6,32 +6,24 @@ interface SwipeButtonsProps {
   onPass: () => void;
   onLike: () => void;
   onSuperLike: () => void;
+  onUndo?: () => void;
+  canUndo?: boolean;
   superLikeUsed: boolean;
   disabled: boolean;
 }
 
-export default function SwipeButtons({ onPass, onLike, onSuperLike, superLikeUsed, disabled }: SwipeButtonsProps) {
+export default function SwipeButtons({ onPass, onLike, onSuperLike, onUndo, canUndo, superLikeUsed, disabled }: SwipeButtonsProps) {
   return (
-    <div className="flex items-center justify-center gap-6 mt-4">
-      {/* Pass */}
-      <motion.button
-        onClick={onPass}
-        disabled={disabled}
-        className="w-14 h-14 rounded-full bg-dark-surface border-2 border-accent-red flex items-center justify-center text-accent-red text-2xl disabled:opacity-30 transition-opacity"
-        whileTap={{ scale: 0.85 }}
-      >
-        ✕
-      </motion.button>
-
-      {/* Super Like */}
+    <div className="flex flex-col items-center gap-3 mt-4">
+      {/* Super Like — above the main row, centred */}
       <div className="relative">
-        {/* Pulsing ring — CSS animation, no Framer Motion to avoid flicker */}
         {!superLikeUsed && !disabled && (
           <span className="absolute inset-0 rounded-full border-2 border-accent-gold animate-ping opacity-60" />
         )}
         <motion.button
           onClick={onSuperLike}
           disabled={disabled || superLikeUsed}
+          title="Super Like (once per game)"
           className={`relative w-12 h-12 rounded-full border-2 flex items-center justify-center text-xl transition-all ${
             superLikeUsed
               ? 'bg-dark-surface border-gray-600 text-gray-600 opacity-40'
@@ -43,15 +35,41 @@ export default function SwipeButtons({ onPass, onLike, onSuperLike, superLikeUse
         </motion.button>
       </div>
 
-      {/* Like */}
-      <motion.button
-        onClick={onLike}
-        disabled={disabled}
-        className="w-14 h-14 rounded-full bg-dark-surface border-2 border-accent-green flex items-center justify-center text-accent-green text-2xl disabled:opacity-30 transition-opacity"
-        whileTap={{ scale: 0.85 }}
-      >
-        ♥
-      </motion.button>
+      {/* Pass + Like — main action row */}
+      <div className="flex items-center gap-6">
+        {/* Pass */}
+        <motion.button
+          onClick={onPass}
+          disabled={disabled}
+          className="w-16 h-16 rounded-full bg-dark-surface border-2 border-accent-red flex items-center justify-center text-accent-red text-2xl disabled:opacity-30 transition-opacity"
+          whileTap={{ scale: 0.85 }}
+        >
+          ✕
+        </motion.button>
+
+        {/* Like */}
+        <motion.button
+          onClick={onLike}
+          disabled={disabled}
+          className="w-16 h-16 rounded-full bg-dark-surface border-2 border-accent-green flex items-center justify-center text-accent-green text-2xl disabled:opacity-30 transition-opacity"
+          whileTap={{ scale: 0.85 }}
+        >
+          ♥
+        </motion.button>
+
+        {/* Undo — small, to the right */}
+        {onUndo !== undefined && (
+          <motion.button
+            onClick={onUndo}
+            disabled={!canUndo}
+            className="w-10 h-10 rounded-full bg-dark-surface border border-dark-border flex items-center justify-center text-gray-400 hover:text-white disabled:opacity-30 transition-colors"
+            whileTap={{ scale: 0.9 }}
+            title="Undo last swipe"
+          >
+            ↩
+          </motion.button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import {
   motion,
   useMotionValue,
@@ -31,6 +31,15 @@ export default function SwipeCard({
 }: SwipeCardProps) {
   const [flipped, setFlipped] = useState(false);
   const [exiting, setExiting] = useState(false);
+  const backScrollRef = useRef<HTMLDivElement>(null);
+
+  // Reset scroll position when card is un-flipped
+  useEffect(() => {
+    if (!flipped && backScrollRef.current) {
+      backScrollRef.current.scrollTop = 0;
+    }
+  }, [flipped]);
+
   const x = useMotionValue(0);
   const y = useMotionValue(0);
   const rotate = useTransform(x, [-250, 0, 250], [-18, 0, 18]);
@@ -102,8 +111,8 @@ export default function SwipeCard({
     >
       <motion.div
         className="relative cursor-grab active:cursor-grabbing select-none h-full"
-        style={{ x, y, rotate, touchAction: 'none' }}
-        drag={isTop && !exiting ? true : false}
+        style={{ x, y, rotate, touchAction: flipped ? 'pan-y' : 'none' }}
+        drag={isTop && !exiting ? (flipped ? 'x' : true) : false}
         dragElastic={0.8}
         onDragEnd={isTop ? handleDragEnd : undefined}
         onClick={handleTap}
@@ -127,20 +136,38 @@ export default function SwipeCard({
             transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
             style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d' }}
           >
-            {/* Poster — flex-1 fills whatever height remains after the info
-                strip.  Parent now has a *definite* height (h-full from the
-                chain above) so flex-1 + min-h-0 works correctly. */}
+            {/* Poster — flex-1 fills remaining height. object-cover + blurred
+                background fill so any non-standard aspect ratio looks immersive
+                rather than leaving black bars. */}
             <div className="relative bg-dark-surface w-full flex-1 min-h-0 overflow-hidden">
               {card.posterPath ? (
-                <img
-                  src={card.posterPath}
-                  alt={card.title}
-                  className="w-full h-full object-contain object-center"
-                  draggable={false}
-                />
+                <>
+                  {/* Blurred background fill */}
+                  <img
+                    src={card.posterPath}
+                    aria-hidden="true"
+                    className="absolute inset-0 w-full h-full object-cover blur-2xl scale-110 opacity-25"
+                    draggable={false}
+                  />
+                  {/* Crisp poster */}
+                  <img
+                    src={card.posterPath}
+                    alt={card.title}
+                    className="relative w-full h-full object-contain object-center"
+                    draggable={false}
+                  />
+                </>
               ) : (
                 <div className="w-full h-full flex items-center justify-center text-gray-600 text-sm">No Poster</div>
               )}
+              {/* Media type badge */}
+              <span className="absolute top-2 left-2 bg-black/60 backdrop-blur-sm text-white text-xs font-medium px-2 py-0.5 rounded-full">
+                {card.mediaType === 'movie' ? '🎬 Film' : '📺 Series'}
+              </span>
+              {/* Info icon — tap-for-details hint */}
+              <span className="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 backdrop-blur-sm flex items-center justify-center text-white/70 text-sm select-none pointer-events-none">
+                ⓘ
+              </span>
             </div>
 
             {/* Info strip — fixed height, never shrinks or grows */}
@@ -150,11 +177,13 @@ export default function SwipeCard({
               </h2>
 
               <div className="flex gap-3 text-sm items-center">
-                <span className="flex items-center gap-1">
-                  <span className="text-yellow-400">★</span>
-                  <span>{card.voteAverage.toFixed(1)}</span>
-                  <span className="text-gray-600 text-xs">IMDB</span>
-                </span>
+                {card.voteAverage > 0 && (
+                  <span className="flex items-center gap-1">
+                    <span className="text-yellow-400">★</span>
+                    <span>{card.voteAverage.toFixed(1)}</span>
+                    <span className="text-gray-600 text-xs">IMDB</span>
+                  </span>
+                )}
                 {card.rottenTomatoesScore !== null && (
                   <span className="flex items-center gap-1">
                     <span>🍅</span>
@@ -173,7 +202,6 @@ export default function SwipeCard({
               </div>
 
               {card.providers.length > 0 && <StreamingLogos providers={card.providers} />}
-              <p className="text-xs text-gray-600 text-center">Tap for details ↕</p>
             </div>
           </motion.div>
 
@@ -184,7 +212,7 @@ export default function SwipeCard({
             transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
             style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d' }}
           >
-            <div className="p-5 h-full overflow-y-auto space-y-4">
+            <div ref={backScrollRef} className="p-5 h-full overflow-y-auto space-y-4">
               <h2 className="text-xl font-bold leading-tight">{card.title} <span className="text-gray-500 font-normal text-base">({card.year})</span></h2>
 
               <div className="flex gap-3 flex-wrap">

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -15,6 +15,14 @@ export default function HeroSection() {
       >
         Swipe. Match. Watch.
       </motion.p>
+      <motion.p
+        className="mt-2 text-sm text-gray-600 max-w-xs mx-auto"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.6 }}
+      >
+        Pick movies everyone agrees on — swipe with friends, match wins.
+      </motion.p>
     </div>
   );
 }

--- a/apps/web/src/components/lobby/FilterPanel.tsx
+++ b/apps/web/src/components/lobby/FilterPanel.tsx
@@ -202,7 +202,7 @@ export default function FilterPanel({ settings, onSettingsChange, isCreator }: F
         <input
           type="range"
           min={0}
-          max={10}
+          max={9}
           step={0.5}
           value={settings.minRating}
           onChange={e => update({ minRating: parseFloat(e.target.value) })}

--- a/apps/web/src/components/results/WildcardPicker.tsx
+++ b/apps/web/src/components/results/WildcardPicker.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { TitleCard } from '@/types/game';
 import Confetti from './Confetti';
+import { useSound } from '@/hooks/useSound';
 
 interface WildcardPickerProps {
   candidates: TitleCard[];
@@ -14,6 +15,7 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
   const [winner, setWinner] = useState<TitleCard | null>(null);
   const [displayIndex, setDisplayIndex] = useState(0);
   const intervalRef = useRef<NodeJS.Timeout>();
+  const { playTick, playWildcard } = useSound();
 
   const handleSpin = useCallback(() => {
     if (spinning || candidates.length === 0) return;
@@ -26,12 +28,15 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
     const tick = () => {
       idx = (idx + 1) % candidates.length;
       setDisplayIndex(idx);
+      playTick();
       speed += 15;
 
       if (speed > 400) {
         setSpinning(false);
         const selected = candidates[Math.floor(Math.random() * candidates.length)];
         setWinner(selected);
+        // Small delay so last tick sound clears, then play win sound
+        setTimeout(() => playWildcard(), 150);
         return;
       }
 
@@ -39,7 +44,7 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
     };
 
     tick();
-  }, [candidates, spinning]);
+  }, [candidates, spinning, playTick, playWildcard]);
 
   if (candidates.length === 0) {
     return <p className="text-gray-400 text-center">No close matches found.</p>;

--- a/apps/web/src/types/socket.ts
+++ b/apps/web/src/types/socket.ts
@@ -19,6 +19,8 @@ export interface ServerToClientEvents {
 export interface ClientToServerEvents {
   createRoom: (playerName: string, callback: (response: { room: import('./game').Room } | { error: string }) => void) => void;
   joinRoom: (code: string, playerName: string, callback: (response: { room: import('./game').Room } | { error: string }) => void) => void;
+  checkRoom: (code: string, callback: (response: { exists: boolean; error?: string }) => void) => void;
+  rejoinGame: (payload: { code: string; displayName: string }) => void;
   updateSettings: (settings: GameSettings) => void;
   requestTitleCount: (settings: GameSettings) => void;
   startGame: () => void;


### PR DESCRIPTION
Closes #87

## Bugs fixed
- **RT score for TV shows** — OMDB call was movie-only; now fetches for both
- **Min rating slider** — capped at 9 (setting 10 previously gave only fringe perfect-score titles)
- **Card detail swipe** — flipped card now swipes L/R while detail scrolls vertically (`drag='x'` + `touchAction:'pan-y'` when flipped); back-face scroll resets on un-flip
- **Build errors** — `Array.from(map.values())`, Logo size, socket `checkRoom`/`rejoinGame` types

## Cards
- Blurred background fill behind poster
- Media type badge (🎬 Film / 📺 Series)
- ⓘ icon for 'tap for details'

## Game
- Superlike button above pass/like row; undo in same row
- Keyboard shortcuts: ← pass, → like, ↑ superlike
- Progress bar: 'N left' count only
- 'All done' screen: live progress bars per player

## Results
- Sticky footer (Share / Play Again / End Game)
- Watch Now streaming links on winner card

## Other
- Wildcard: tick + win sounds
- Lobby: invite hint when < 2 players
- Home: one-liner tagline
- Toast: safe-area-inset-top for notched iPhones