### PR TITLE
fix: Metacritic score fallback when RT unavailable

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -155,6 +155,8 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
             const omdb = await omdbRes.json();
             const rt = (omdb.Ratings || []).find((r: any) => r.Source === 'Rotten Tomatoes');
             title.rottenTomatoesScore = rt ? parseInt(rt.Value) : null;
+            const mc = omdb.Metascore && omdb.Metascore !== 'N/A' ? parseInt(omdb.Metascore) : null;
+            title.metacriticScore = mc;
           }
         } catch { /* OMDB failure is non-critical */ }
       }
@@ -231,6 +233,7 @@ function mapBasicResult(item: any, mediaType: 'movie' | 'tv'): TitleCard {
     overview: item.overview || '',
     voteAverage: item.vote_average || 0,
     rottenTomatoesScore: null,
+    metacriticScore: null,
     runtime: null,
     genres: (item.genre_ids || []).map((id: number) => GENRE_MAP[id] || 'Unknown'),
     contentRating: '',

--- a/apps/socket-server/src/types.ts
+++ b/apps/socket-server/src/types.ts
@@ -22,6 +22,7 @@ export interface TitleCard {
   overview: string;
   voteAverage: number;
   rottenTomatoesScore: number | null;
+  metacriticScore: number | null;
   runtime: number | null;
   genres: string[];
   contentRating: string;

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -199,12 +199,17 @@ export default function SwipeCard({
                     <span>{card.voteAverage.toFixed(1)}</span>
                   </span>
                 )}
-                {card.rottenTomatoesScore !== null && (
+                {card.rottenTomatoesScore !== null ? (
                   <span className="flex items-center gap-1">
                     <span>🍅</span>
                     <span>{card.rottenTomatoesScore}%</span>
                   </span>
-                )}
+                ) : card.metacriticScore !== null ? (
+                  <span className="flex items-center gap-1.5">
+                    <span className="bg-[#FFCC34] text-black text-[10px] font-extrabold px-1.5 py-0.5 rounded leading-none">MC</span>
+                    <span>{card.metacriticScore}</span>
+                  </span>
+                ) : null}
               </div>
 
               <div className="flex flex-wrap gap-1">
@@ -236,6 +241,12 @@ export default function SwipeCard({
                   <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
                     <div className="text-red-400 text-lg font-bold">{card.rottenTomatoesScore}%</div>
                     <div className="text-xs text-gray-500">RT</div>
+                  </div>
+                )}
+                {card.rottenTomatoesScore === null && card.metacriticScore !== null && (
+                  <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
+                    <div className="text-yellow-400 text-lg font-bold">{card.metacriticScore}</div>
+                    <div className="text-xs text-gray-500">MC</div>
                   </div>
                 )}
                 {card.runtime && (

--- a/apps/web/src/components/results/ResultReveal.tsx
+++ b/apps/web/src/components/results/ResultReveal.tsx
@@ -88,12 +88,17 @@ export default function ResultReveal({ winner, skipCountdown = false }: ResultRe
                       <span className="bg-[#F5C518] text-black text-[10px] font-extrabold px-1.5 py-0.5 rounded leading-none">IMDb</span>
                       <span>{winner.voteAverage.toFixed(1)}</span>
                     </span>
-                    {winner.rottenTomatoesScore !== null && (
+                    {winner.rottenTomatoesScore !== null ? (
                       <span className="flex items-center gap-1">
                         <span>🍅</span>
                         <span>{winner.rottenTomatoesScore}%</span>
                       </span>
-                    )}
+                    ) : winner.metacriticScore !== null ? (
+                      <span className="flex items-center gap-1.5">
+                        <span className="bg-[#FFCC34] text-black text-[10px] font-extrabold px-1.5 py-0.5 rounded leading-none">MC</span>
+                        <span>{winner.metacriticScore}</span>
+                      </span>
+                    ) : null}
                   </div>
                   {winner.providers && winner.providers.length > 0 && (
                     <div className="flex justify-center pt-1">
@@ -126,6 +131,12 @@ export default function ResultReveal({ winner, skipCountdown = false }: ResultRe
                       <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
                         <div className="text-red-400 text-lg font-bold">{winner.rottenTomatoesScore}%</div>
                         <div className="text-xs text-gray-500">RT</div>
+                      </div>
+                    )}
+                    {winner.rottenTomatoesScore === null && winner.metacriticScore !== null && (
+                      <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
+                        <div className="text-yellow-400 text-lg font-bold">{winner.metacriticScore}</div>
+                        <div className="text-xs text-gray-500">MC</div>
                       </div>
                     )}
                     {winner.runtime && (

--- a/apps/web/src/types/game.ts
+++ b/apps/web/src/types/game.ts
@@ -22,6 +22,7 @@ export interface TitleCard {
   overview: string;
   voteAverage: number;
   rottenTomatoesScore: number | null;
+  metacriticScore: number | null;
   runtime: number | null;
   genres: string[];
   contentRating: string;


### PR DESCRIPTION
Closes #91\n\nAdds metacriticScore field. UI shows 🍅 RT when available, falls back to MC badge otherwise.