### PR TITLE
fix: prevent image drag interference during card swipe

### DIFF
--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -118,7 +118,13 @@ export default function SwipeCard({
     >
       <motion.div
         className="relative cursor-grab active:cursor-grabbing select-none h-full"
-        style={{ x, y, rotate, touchAction: flipped ? 'pan-y' : 'none' }}
+        style={{
+          x, y, rotate,
+          touchAction: flipped ? 'pan-y' : 'none',
+          WebkitUserSelect: 'none',
+          WebkitTouchCallout: 'none',
+          willChange: 'transform',
+        } as React.CSSProperties}
         drag={!preview && isTop && !exiting ? (flipped ? 'x' : true) : false}
         dragElastic={0.8}
         onDragEnd={isTop ? handleDragEnd : undefined}
@@ -151,15 +157,17 @@ export default function SwipeCard({
                   <img
                     src={card.posterPath}
                     aria-hidden="true"
-                    className="absolute inset-0 w-full h-full object-cover blur-2xl scale-110 opacity-25"
+                    className="absolute inset-0 w-full h-full object-cover blur-2xl scale-110 opacity-25 pointer-events-none"
                     draggable={false}
+                    onDragStart={e => e.preventDefault()}
                   />
                   {/* Crisp poster */}
                   <img
                     src={card.posterPath}
                     alt={card.title}
-                    className="relative w-full h-full object-contain object-center"
+                    className="relative w-full h-full object-contain object-center pointer-events-none"
                     draggable={false}
+                    onDragStart={e => e.preventDefault()}
                   />
                 </>
               ) : (


### PR DESCRIPTION
On both mobile and desktop, native browser image dragging was occasionally fighting Framer Motion's gesture handler, making swipes feel flaky.

Three-layer fix:
- **`pointer-events-none`** on both `<img>` elements (blurred bg + poster) — all pointer events pass through to the Framer Motion card div
- **`onDragStart={e => e.preventDefault()}`** on both images — suppresses the native HTML drag API ghost image
- **`WebkitUserSelect: none`, `WebkitTouchCallout: none`** on the drag container — prevents iOS callout/selection on long-press
- **`willChange: 'transform'`** — hints GPU compositing layer for smoother animation