### PR TITLE
feat: highlight swipe buttons live during card drag

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -52,6 +52,7 @@ export default function GamePage() {
   const [showTutorial, setShowTutorial] = useState(false);
   const [canUndo, setCanUndo] = useState(false);
   const [pendingDecision, setPendingDecision] = useState<'like' | 'pass' | 'superlike' | null>(null);
+  const [dragDirection, setDragDirection] = useState<'like' | 'pass' | 'superlike' | null>(null);
 
   useEffect(() => {
     if (!room || !titlePool.length) {
@@ -167,6 +168,7 @@ export default function GamePage() {
             totalCards={titlePool.length}
             onUndo={handleUndo}
             canUndo={canUndo}
+            onDragProgress={setDragDirection}
           />
         </div>
 
@@ -178,6 +180,7 @@ export default function GamePage() {
             onSuperLike={() => setPendingDecision('superlike')}
             superLikeUsed={me?.superLikeUsed ?? false}
             disabled={isFinished || !!pendingDecision}
+            dragDirection={dragDirection}
           />
         )}
       </div>

--- a/apps/web/src/components/game/CardStack.tsx
+++ b/apps/web/src/components/game/CardStack.tsx
@@ -17,6 +17,7 @@ interface CardStackProps {
   totalCards?: number;
   onUndo?: () => void;
   canUndo?: boolean;
+  onDragProgress?: (direction: 'like' | 'pass' | 'superlike' | null) => void;
 }
 
 export default function CardStack({
@@ -25,6 +26,7 @@ export default function CardStack({
   pendingDecision, onPendingConsumed,
   otherPlayers = [], totalCards,
   onUndo, canUndo = false,
+  onDragProgress,
 }: CardStackProps) {
   if (currentIndex >= cards.length) {
     const total = totalCards ?? cards.length;
@@ -104,6 +106,7 @@ export default function CardStack({
             onPendingConsumed={isTop ? onPendingConsumed : undefined}
             onUndo={isTop ? onUndo : undefined}
             canUndo={isTop ? canUndo : false}
+            onDragProgress={isTop ? onDragProgress : undefined}
           />
         );
       })}

--- a/apps/web/src/components/game/SwipeButtons.tsx
+++ b/apps/web/src/components/game/SwipeButtons.tsx
@@ -8,53 +8,81 @@ interface SwipeButtonsProps {
   onSuperLike: () => void;
   superLikeUsed: boolean;
   disabled: boolean;
+  /** Which direction the card is currently being dragged toward */
+  dragDirection?: 'like' | 'pass' | 'superlike' | null;
 }
 
-export default function SwipeButtons({ onPass, onLike, onSuperLike, superLikeUsed, disabled }: SwipeButtonsProps) {
+export default function SwipeButtons({
+  onPass, onLike, onSuperLike,
+  superLikeUsed, disabled,
+  dragDirection = null,
+}: SwipeButtonsProps) {
+  const passActive   = dragDirection === 'pass';
+  const likeActive   = dragDirection === 'like';
+  const superActive  = dragDirection === 'superlike';
+
   return (
     <div className="flex justify-center mt-3">
       <div className="flex items-center gap-7 glass-card rounded-[2rem] px-8 py-4 shadow-card">
 
-        {/* Pass */}
+        {/* Pass ✕ */}
         <motion.button
           onClick={onPass}
           disabled={disabled}
-          className="w-[62px] h-[62px] rounded-full bg-dark-surface border-2 border-accent-red flex items-center justify-center text-accent-red text-[1.6rem] font-black disabled:opacity-30 transition-shadow hover:shadow-[0_0_32px_rgba(255,23,68,0.55)]"
+          animate={{
+            backgroundColor: passActive ? 'rgba(255,23,68,1)' : 'rgba(15,14,31,0)',
+            borderColor: passActive ? 'rgba(255,23,68,1)' : 'rgba(255,23,68,0.8)',
+            scale: passActive ? 1.15 : 1,
+          }}
+          transition={{ type: 'spring', stiffness: 400, damping: 22 }}
+          className="w-[62px] h-[62px] rounded-full border-2 flex items-center justify-center text-[1.6rem] font-black disabled:opacity-30"
+          style={{ color: passActive ? '#fff' : '#ff1744', boxShadow: passActive ? '0 0 32px rgba(255,23,68,0.7)' : undefined }}
           whileTap={{ scale: 0.80 }}
-          whileHover={{ scale: 1.06 }}
           title="Nope"
         >
           ✕
         </motion.button>
 
-        {/* Super Like — centre, slightly smaller */}
+        {/* Super Like ★ */}
         <div className="relative">
-          {!superLikeUsed && !disabled && (
+          {!superLikeUsed && !disabled && !superActive && (
             <span className="absolute inset-0 rounded-full border-2 border-accent-gold animate-ping opacity-40" />
           )}
           <motion.button
             onClick={onSuperLike}
             disabled={disabled || superLikeUsed}
-            title="Super Like (once per game)"
-            className={`relative w-12 h-12 rounded-full border-2 flex items-center justify-center text-xl transition-shadow ${
-              superLikeUsed
-                ? 'bg-dark-surface border-gray-700 text-gray-700 opacity-25'
-                : 'bg-dark-surface border-accent-gold text-accent-gold hover:shadow-[0_0_28px_rgba(255,215,0,0.55)]'
-            }`}
+            animate={{
+              backgroundColor: superActive ? 'rgba(255,215,0,1)' : 'rgba(15,14,31,0)',
+              borderColor: superLikeUsed ? 'rgba(107,107,107,0.4)' : superActive ? 'rgba(255,215,0,1)' : 'rgba(255,215,0,0.9)',
+              scale: superActive ? 1.18 : 1,
+            }}
+            transition={{ type: 'spring', stiffness: 400, damping: 22 }}
+            className="relative w-12 h-12 rounded-full border-2 flex items-center justify-center text-xl"
+            style={{
+              color: superLikeUsed ? 'rgba(107,107,107,0.4)' : superActive ? '#000' : '#ffd700',
+              opacity: superLikeUsed ? 0.25 : 1,
+              boxShadow: superActive ? '0 0 28px rgba(255,215,0,0.8)' : undefined,
+            }}
             whileTap={{ scale: 0.80 }}
-            whileHover={superLikeUsed ? {} : { scale: 1.06 }}
+            title="Super Like (once per game)"
           >
             ★
           </motion.button>
         </div>
 
-        {/* Like */}
+        {/* Like ♥ */}
         <motion.button
           onClick={onLike}
           disabled={disabled}
-          className="w-[62px] h-[62px] rounded-full bg-dark-surface border-2 border-accent-green flex items-center justify-center text-accent-green text-[1.6rem] font-black disabled:opacity-30 transition-shadow hover:shadow-[0_0_32px_rgba(0,200,83,0.55)]"
+          animate={{
+            backgroundColor: likeActive ? 'rgba(0,200,83,1)' : 'rgba(15,14,31,0)',
+            borderColor: likeActive ? 'rgba(0,200,83,1)' : 'rgba(0,200,83,0.8)',
+            scale: likeActive ? 1.15 : 1,
+          }}
+          transition={{ type: 'spring', stiffness: 400, damping: 22 }}
+          className="w-[62px] h-[62px] rounded-full border-2 flex items-center justify-center text-[1.6rem] font-black disabled:opacity-30"
+          style={{ color: likeActive ? '#fff' : '#00c853', boxShadow: likeActive ? '0 0 32px rgba(0,200,83,0.7)' : undefined }}
           whileTap={{ scale: 0.80 }}
-          whileHover={{ scale: 1.06 }}
           title="Like"
         >
           ♥

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import {
   motion,
   useMotionValue,
+  useMotionValueEvent,
   useTransform,
   animate,
   type PanInfo,
@@ -27,12 +28,15 @@ interface SwipeCardProps {
   canUndo?: boolean;
   /** Preview mode: static card, tap to flip, no swiping */
   preview?: boolean;
+  /** Called every frame during drag with the active direction (null = snapped back) */
+  onDragProgress?: (direction: 'like' | 'pass' | 'superlike' | null) => void;
 }
 
 export default function SwipeCard({
   card, onSwipe, isTop, stackIndex,
   superLikeUsed = false,
   pendingDecision, onPendingConsumed,
+  onDragProgress,
   onUndo, canUndo = false,
   preview = false,
 }: SwipeCardProps) {
@@ -54,6 +58,22 @@ export default function SwipeCard({
   const nopeOpacity       = useTransform(x, [-120, -20], [1, 0]);
   const superLikeOpacity  = useTransform(y, [-120, -20], [1, 0]);
   const decisionRef = useRef<'like' | 'pass' | 'superlike'>('pass');
+
+  // Emit drag direction to parent so SwipeButtons can highlight the active button
+  useMotionValueEvent(x, 'change', (latest) => {
+    if (!isTop || exiting || !onDragProgress) return;
+    if (latest > 30) onDragProgress('like');
+    else if (latest < -30) onDragProgress('pass');
+    else if (y.get() < -30) onDragProgress('superlike');
+    else onDragProgress(null);
+  });
+  useMotionValueEvent(y, 'change', (latest) => {
+    if (!isTop || exiting || !onDragProgress) return;
+    if (latest < -30 && Math.abs(x.get()) < 30) onDragProgress('superlike');
+    else if (x.get() > 30) onDragProgress('like');
+    else if (x.get() < -30) onDragProgress('pass');
+    else onDragProgress(null);
+  });
 
   const scale = 1 - stackIndex * 0.05;
   const yOffset = stackIndex * 10;
@@ -98,7 +118,8 @@ export default function SwipeCard({
     if (swipedH) {
       flyOut(info.offset.x > 0 ? 'like' : 'pass');
     } else {
-      // Snap back smoothly
+      // Snap back smoothly, clear the highlight
+      onDragProgress?.(null);
       animate(x, 0, { type: 'spring', stiffness: 400, damping: 30 });
       animate(y, 0, { type: 'spring', stiffness: 400, damping: 30 });
     }


### PR DESCRIPTION
When dragging a card, the corresponding button now fills with its color and glows:
- Drag right → ♥ fills green + green glow
- Drag left → ✕ fills red + red glow  
- Drag up → ★ fills gold + gold glow

Implementation:
- `SwipeCard` emits `onDragProgress(direction)` via `useMotionValueEvent` on every x/y frame change (threshold: 30px)
- `CardStack` threads `onDragProgress` to the top card only
- Game page holds `dragDirection` state, passes to both `CardStack` and `SwipeButtons`
- `SwipeButtons` uses Framer Motion `animate` to spring-transition `backgroundColor`, `borderColor`, and `scale` based on `dragDirection`