### PR TITLE
feat: drastic redesign — full-bleed cinematic cards + home page overhaul

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import HeroSection from '@/components/landing/HeroSection';
 import CreateGameButton from '@/components/landing/CreateGameButton';
 import JoinGameForm from '@/components/landing/JoinGameForm';
 import GameHistoryButton from '@/components/landing/GameHistoryButton';
@@ -20,72 +19,87 @@ export default function Home() {
   }, []);
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-6 relative overflow-hidden bg-dark">
-      {/* Background atmosphere */}
+    <main className="flex min-h-screen flex-col items-center justify-center px-5 py-10 relative overflow-hidden bg-dark">
+
+      {/* ── Atmospheric background ── */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        {/* Primary red bloom — top */}
         <motion.div
-          className="absolute -top-32 left-1/2 -translate-x-1/2 w-[500px] h-[350px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(229,9,20,0.14) 0%, transparent 70%)' }}
-          animate={{ scale: [1, 1.12, 1], opacity: [0.7, 1, 0.7] }}
+          className="absolute -top-40 left-1/2 -translate-x-1/2 w-[600px] h-[400px] rounded-full"
+          style={{ background: 'radial-gradient(ellipse, rgba(229,9,20,0.18) 0%, transparent 65%)' }}
+          animate={{ scale: [1, 1.1, 1], opacity: [0.7, 1, 0.7] }}
           transition={{ duration: 7, repeat: Infinity, ease: 'easeInOut' }}
         />
-        {/* Orange accent — right */}
         <motion.div
-          className="absolute top-1/4 -right-24 w-[320px] h-[320px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(255,107,53,0.08) 0%, transparent 70%)' }}
-          animate={{ scale: [1.1, 1, 1.1], opacity: [0.5, 0.8, 0.5] }}
-          transition={{ duration: 9, repeat: Infinity, ease: 'easeInOut', delay: 1 }}
+          className="absolute bottom-0 -right-32 w-[400px] h-[400px] rounded-full"
+          style={{ background: 'radial-gradient(ellipse, rgba(109,40,217,0.1) 0%, transparent 65%)' }}
+          animate={{ scale: [1.1, 1, 1.1], opacity: [0.4, 0.7, 0.4] }}
+          transition={{ duration: 10, repeat: Infinity, ease: 'easeInOut', delay: 1 }}
         />
-        {/* Violet depth — bottom left */}
         <motion.div
-          className="absolute -bottom-24 -left-24 w-[380px] h-[380px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(109,40,217,0.08) 0%, transparent 70%)' }}
-          animate={{ scale: [1, 1.15, 1], opacity: [0.4, 0.7, 0.4] }}
-          transition={{ duration: 11, repeat: Infinity, ease: 'easeInOut', delay: 2 }}
-        />
-        {/* Subtle center glow */}
-        <div
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[400px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(229,9,20,0.03) 0%, transparent 65%)' }}
+          className="absolute top-1/3 -left-24 w-[300px] h-[300px] rounded-full"
+          style={{ background: 'radial-gradient(ellipse, rgba(255,107,53,0.07) 0%, transparent 65%)' }}
+          animate={{ scale: [1, 1.15, 1], opacity: [0.3, 0.6, 0.3] }}
+          transition={{ duration: 9, repeat: Infinity, ease: 'easeInOut', delay: 3 }}
         />
       </div>
 
-      {/* Content */}
-      <div className="relative z-10 w-full max-w-md flex flex-col items-center gap-3">
-        <HeroSection />
+      {/* ── Content ── */}
+      <div className="relative z-10 w-full max-w-sm flex flex-col items-center">
 
-        {/* Main action card */}
+        {/* Logo */}
         <motion.div
-          className="gradient-border w-full rounded-2xl p-5 flex flex-col gap-4"
+          className="text-center mb-10"
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ type: 'spring', stiffness: 220, damping: 22 }}
+        >
+          <h1 className="font-black tracking-tight leading-none" style={{ fontSize: 'clamp(3rem, 16vw, 4.5rem)' }}>
+            <span className="text-white">Show</span>
+            <span className="gradient-text">Match</span>
+          </h1>
+          <p className="mt-2 text-sm text-gray-500 tracking-[0.25em] uppercase font-medium">
+            Swipe · Match · Watch
+          </p>
+        </motion.div>
+
+        {/* Actions */}
+        <motion.div
+          className="w-full flex flex-col gap-3"
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.15, type: 'spring', stiffness: 260, damping: 24 }}
+          transition={{ delay: 0.12, type: 'spring', stiffness: 240, damping: 24 }}
         >
           <CreateGameButton />
 
-          <div className="flex items-center gap-3 text-gray-600 text-xs">
+          <div className="flex items-center gap-3 text-gray-700 text-xs my-1">
             <div className="flex-1 h-px bg-dark-border" />
-            <span className="tracking-wider uppercase">or join with a code</span>
+            <span className="tracking-widest uppercase">or</span>
             <div className="flex-1 h-px bg-dark-border" />
           </div>
 
           <JoinGameForm />
         </motion.div>
 
-        <GameHistoryButton />
+        <motion.div
+          className="mt-6"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.4 }}
+        >
+          <GameHistoryButton />
+        </motion.div>
       </div>
 
       {/* Toast */}
       <AnimatePresence>
         {toast && (
           <motion.div
-            className="fixed left-1/2 -translate-x-1/2 glass-card px-6 py-3 rounded-2xl text-sm z-50 whitespace-nowrap shadow-card"
+            className="fixed left-1/2 -translate-x-1/2 glass-card px-5 py-3 rounded-2xl text-sm z-50 whitespace-nowrap"
             style={{ top: 'max(1rem, env(safe-area-inset-top))' }}
-            initial={{ opacity: 0, y: -16 }}
+            initial={{ opacity: 0, y: -12 }}
             animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -16 }}
-            transition={{ type: 'spring', stiffness: 400, damping: 28 }}
+            exit={{ opacity: 0, y: -12 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
           >
             {toast}
           </motion.div>

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -18,17 +18,12 @@ interface SwipeCardProps {
   onSwipe: (decision: 'like' | 'pass' | 'superlike') => void;
   isTop: boolean;
   stackIndex: number;
-  /** Whether this player has already used their one superlike this game */
   superLikeUsed?: boolean;
-  /** Programmatic trigger from buttons: set to fire an exit animation */
   pendingDecision?: 'like' | 'pass' | 'superlike' | null;
   onPendingConsumed?: () => void;
-  /** Undo last swipe — shown as a small button on the card */
   onUndo?: () => void;
   canUndo?: boolean;
-  /** Preview mode: static card, tap to flip, no swiping */
   preview?: boolean;
-  /** Called every frame during drag with the active direction (null = snapped back) */
   onDragProgress?: (direction: 'like' | 'pass' | 'superlike' | null) => void;
 }
 
@@ -44,7 +39,6 @@ export default function SwipeCard({
   const [exiting, setExiting] = useState(false);
   const backScrollRef = useRef<HTMLDivElement>(null);
 
-  // Reset scroll position when card is un-flipped
   useEffect(() => {
     if (!flipped && backScrollRef.current) {
       backScrollRef.current.scrollTop = 0;
@@ -54,12 +48,11 @@ export default function SwipeCard({
   const x = useMotionValue(0);
   const y = useMotionValue(0);
   const rotate = useTransform(x, [-250, 0, 250], [-18, 0, 18]);
-  const likeOpacity       = useTransform(x, [20, 120], [0, 1]);
-  const nopeOpacity       = useTransform(x, [-120, -20], [1, 0]);
-  const superLikeOpacity  = useTransform(y, [-120, -20], [1, 0]);
+  const likeOpacity      = useTransform(x, [20, 120], [0, 1]);
+  const nopeOpacity      = useTransform(x, [-120, -20], [1, 0]);
+  const superLikeOpacity = useTransform(y, [-120, -20], [1, 0]);
   const decisionRef = useRef<'like' | 'pass' | 'superlike'>('pass');
 
-  // Emit drag direction to parent so SwipeButtons can highlight the active button
   useMotionValueEvent(x, 'change', (latest) => {
     if (!isTop || exiting || !onDragProgress) return;
     if (latest > 30) onDragProgress('like');
@@ -75,50 +68,37 @@ export default function SwipeCard({
     else onDragProgress(null);
   });
 
-  const scale = 1 - stackIndex * 0.05;
-  const yOffset = stackIndex * 10;
+  const scale = 1 - stackIndex * 0.04;
+  const yOffset = stackIndex * 8;
 
-  // Fly the card off screen, then notify parent
   const flyOut = useCallback((decision: 'like' | 'pass' | 'superlike') => {
     if (exiting) return;
     setExiting(true);
     decisionRef.current = decision;
-
-    const targetX = decision === 'pass' ? -700 : decision === 'like' ? 700 : 0;
-    const targetY = decision === 'superlike' ? -700 : 0;
-    const targetRotate = decision === 'pass' ? -25 : decision === 'like' ? 25 : 0;
-
+    const targetX = decision === 'pass' ? -750 : decision === 'like' ? 750 : 0;
+    const targetY = decision === 'superlike' ? -750 : 0;
+    const targetRotate = decision === 'pass' ? -28 : decision === 'like' ? 28 : 0;
     Promise.all([
-      animate(x, targetX, { duration: 0.35, ease: [0.4, 0, 0.2, 1] }),
-      animate(y, targetY, { duration: 0.35, ease: [0.4, 0, 0.2, 1] }),
-      animate(rotate as any, targetRotate, { duration: 0.35 }),
-    ]).then(() => {
-      onSwipe(decision);
-    });
+      animate(x, targetX, { duration: 0.32, ease: [0.4, 0, 0.2, 1] }),
+      animate(y, targetY, { duration: 0.32, ease: [0.4, 0, 0.2, 1] }),
+      animate(rotate as any, targetRotate, { duration: 0.32 }),
+    ]).then(() => onSwipe(decision));
   }, [exiting, x, y, rotate, onSwipe]);
 
-  // Button-triggered swipe (pendingDecision from parent)
   const pendingRef = useRef<typeof pendingDecision>(null);
   if (isTop && pendingDecision && pendingDecision !== pendingRef.current && !exiting) {
     pendingRef.current = pendingDecision;
-    setTimeout(() => {
-      flyOut(pendingDecision);
-      onPendingConsumed?.();
-    }, 0);
+    setTimeout(() => { flyOut(pendingDecision); onPendingConsumed?.(); }, 0);
   }
 
   const handleDragEnd = (_: any, info: PanInfo) => {
     const swipedUp = (info.offset.y < -80 || info.velocity.y < -500) &&
                      Math.abs(info.offset.x) < Math.abs(info.offset.y);
-    if (swipedUp && !superLikeUsed) {
-      flyOut('superlike');
-      return;
-    }
+    if (swipedUp && !superLikeUsed) { flyOut('superlike'); return; }
     const swipedH = Math.abs(info.offset.x) > 100 || Math.abs(info.velocity.x) > 600;
     if (swipedH) {
       flyOut(info.offset.x > 0 ? 'like' : 'pass');
     } else {
-      // Snap back smoothly, clear the highlight
       onDragProgress?.(null);
       animate(x, 0, { type: 'spring', stiffness: 400, damping: 30 });
       animate(y, 0, { type: 'spring', stiffness: 400, damping: 30 });
@@ -129,12 +109,16 @@ export default function SwipeCard({
     if (preview || (isTop && !exiting)) setFlipped(f => !f);
   };
 
+  const cardShadow = isTop
+    ? '0 24px 80px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.07)'
+    : '0 8px 32px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.04)';
+
   return (
     <motion.div
       className="absolute w-full h-full"
-      style={{ zIndex: 10 - stackIndex, filter: isTop ? 'drop-shadow(0 8px 40px rgba(229,9,20,0.12))' : undefined }}
-      initial={{ scale: scale * 0.95, opacity: 0, y: yOffset + 10 }}
-      animate={{ scale, opacity: 1 - stackIndex * 0.1, y: yOffset }}
+      style={{ zIndex: 10 - stackIndex }}
+      initial={{ scale: scale * 0.96, opacity: 0, y: yOffset + 12 }}
+      animate={{ scale, opacity: 1 - stackIndex * 0.08, y: yOffset }}
       transition={{ type: 'spring', stiffness: 300, damping: 28 }}
     >
       <motion.div
@@ -146,163 +130,200 @@ export default function SwipeCard({
         onDragEnd={isTop ? handleDragEnd : undefined}
         onClick={handleTap}
       >
-        {/* Overlay stamps */}
+        {/* Swipe overlay stamps + color wash */}
         {isTop && (
           <CardOverlay
             likeOpacity={likeOpacity}
             nopeOpacity={nopeOpacity}
             superLikeOpacity={superLikeUsed ? undefined : superLikeOpacity}
-            x={x}
-            y={y}
+            x={x} y={y}
           />
         )}
 
-        {/* Card faces wrapper (3D perspective) */}
-        <div className="h-full" style={{ perspective: 1200 }}>
-          {/* Front face — fills the card container via h-full, flex-col splits
-              the poster from the info strip */}
+        {/* 3D flip wrapper */}
+        <div className="relative h-full" style={{ perspective: 1200 }}>
+
+          {/* ── FRONT FACE — full-bleed cinematic poster ── */}
           <motion.div
-            className="bg-dark-card rounded-2xl overflow-hidden border border-dark-border shadow-2xl h-full flex flex-col"
+            className="absolute inset-0 rounded-3xl overflow-hidden"
+            style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d', boxShadow: cardShadow }}
             animate={{ rotateY: flipped ? 180 : 0 }}
-            transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
-            style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d' }}
+            transition={{ duration: 0.42, ease: [0.4, 0, 0.2, 1] }}
           >
-            {/* Poster — flex-1 fills remaining height */}
-            <div className="relative bg-dark-surface w-full flex-1 min-h-0 overflow-hidden">
-              {card.posterPath ? (
-                <>
-                  {/* Blurred background fill */}
-                  <img
-                    src={card.posterPath}
-                    aria-hidden="true"
-                    className="absolute inset-0 w-full h-full object-cover blur-2xl scale-110 opacity-25 pointer-events-none"
-                    draggable={false}
-                    onDragStart={e => e.preventDefault()}
-                  />
-                  {/* Crisp poster */}
-                  <img
-                    src={card.posterPath}
-                    alt={card.title}
-                    className="relative w-full h-full object-contain object-center pointer-events-none"
-                    draggable={false}
-                    onDragStart={e => e.preventDefault()}
-                  />
-                </>
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-gray-600 text-sm">No Poster</div>
-              )}
+            {/* Poster — full bleed */}
+            {card.posterPath ? (
+              <img
+                src={card.posterPath}
+                alt={card.title}
+                className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+                draggable={false}
+                onDragStart={e => e.preventDefault()}
+              />
+            ) : (
+              <div className="absolute inset-0 bg-gradient-to-br from-dark-surface to-dark-card flex items-center justify-center">
+                <span className="text-7xl opacity-10">{card.mediaType === 'movie' ? '🎬' : '📺'}</span>
+              </div>
+            )}
 
-              {/* Undo button — top-left, only on top card when there's something to undo */}
-              {!preview && isTop && onUndo && (
-                <button
-                  onClick={e => { e.stopPropagation(); onUndo(); }}
-                  disabled={!canUndo}
-                  className="absolute top-2 left-2 w-8 h-8 rounded-full bg-black/50 backdrop-blur-sm flex items-center justify-center text-white/70 disabled:opacity-20 transition-opacity"
-                  title="Undo last swipe"
-                >
-                  ↩
-                </button>
-              )}
+            {/* Top vignette — keeps controls readable */}
+            <div className="absolute inset-x-0 top-0 h-28 bg-gradient-to-b from-black/70 via-black/20 to-transparent pointer-events-none" />
 
-              {/* Info icon — top-right, tap-for-details hint */}
-              <span className="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 backdrop-blur-sm flex items-center justify-center text-white/70 text-sm select-none pointer-events-none">
-                ⓘ
-              </span>
+            {/* Bottom gradient + info overlay */}
+            <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/98 via-black/80 to-transparent pt-20 pb-4 px-4 pointer-events-none">
+              {/* Badges row */}
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-[10px] font-bold text-white/60 bg-white/10 backdrop-blur-sm px-2 py-0.5 rounded-full tracking-wide uppercase">
+                  {card.mediaType === 'movie' ? '🎬 Film' : '📺 Series'}
+                </span>
+                {card.contentRating && (
+                  <span className="text-[10px] font-bold text-white/50 bg-white/10 backdrop-blur-sm px-2 py-0.5 rounded-full">
+                    {card.contentRating}
+                  </span>
+                )}
+              </div>
 
-              {/* Media type badge — bottom-right */}
-              <span className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-sm text-white text-xs font-medium px-2 py-0.5 rounded-full">
-                {card.mediaType === 'movie' ? '🎬 Film' : '📺 Series'}
-              </span>
-            </div>
-
-            {/* Info strip — fixed height, never shrinks or grows */}
-            <div className="p-4 space-y-2 shrink-0">
-              <h2 className="font-bold leading-tight" style={{ fontSize: card.title.length > 25 ? '0.95rem' : '1.125rem' }}>
-                {card.title} <span className="text-gray-500 font-normal text-sm">({card.year})</span>
+              {/* Title */}
+              <h2 className="text-white font-black leading-tight tracking-tight" style={{ fontSize: card.title.length > 28 ? '1.1rem' : '1.35rem' }}>
+                {card.title}
               </h2>
+              <p className="text-white/45 text-sm font-medium mt-0.5">{card.year}</p>
 
-              <div className="flex gap-3 text-sm items-center flex-wrap">
+              {/* Ratings */}
+              <div className="flex gap-3 items-center mt-2 flex-wrap">
                 {card.voteAverage > 0 && (
                   <span className="flex items-center gap-1.5">
                     <span className="bg-[#F5C518] text-black text-[10px] font-extrabold px-1.5 py-0.5 rounded leading-none">IMDb</span>
-                    <span>{card.voteAverage.toFixed(1)}</span>
+                    <span className="text-white font-bold text-sm">{card.voteAverage.toFixed(1)}</span>
                   </span>
                 )}
                 {card.rottenTomatoesScore !== null ? (
-                  <span className="flex items-center gap-1">
-                    <span>🍅</span>
-                    <span>{card.rottenTomatoesScore}%</span>
-                  </span>
+                  <span className="flex items-center gap-1 text-white text-sm font-bold">🍅 {card.rottenTomatoesScore}%</span>
                 ) : card.metacriticScore !== null ? (
-                  <span className="flex items-center gap-1.5">
+                  <span className="flex items-center gap-1.5 text-white text-sm font-bold">
                     <span className="bg-[#FFCC34] text-black text-[10px] font-extrabold px-1.5 py-0.5 rounded leading-none">MC</span>
-                    <span>{card.metacriticScore}</span>
+                    {card.metacriticScore}
                   </span>
                 ) : null}
               </div>
 
-              <div className="flex flex-wrap gap-1">
-                {card.genres.map(g => (
-                  <span key={g} className="px-2 py-0.5 bg-dark-surface rounded-full text-xs text-gray-400">{g}</span>
+              {/* Genre chips */}
+              <div className="flex flex-wrap gap-1 mt-2">
+                {card.genres.slice(0, 4).map(g => (
+                  <span key={g} className="px-2 py-0.5 bg-white/12 backdrop-blur-sm rounded-full text-[11px] text-white/75 font-medium">
+                    {g}
+                  </span>
                 ))}
               </div>
 
-              {card.providers.length > 0 && <StreamingLogos providers={card.providers} searchTitle={card.title} />}
+              {/* Providers */}
+              {card.providers.length > 0 && (
+                <div className="mt-2.5 pointer-events-auto">
+                  <StreamingLogos providers={card.providers} searchTitle={card.title} />
+                </div>
+              )}
+            </div>
+
+            {/* Undo — top left */}
+            {!preview && isTop && onUndo && (
+              <button
+                onClick={e => { e.stopPropagation(); onUndo(); }}
+                disabled={!canUndo}
+                className="absolute top-3 left-3 z-10 w-9 h-9 rounded-full bg-black/50 backdrop-blur-md flex items-center justify-center text-white/80 text-base disabled:opacity-20 transition-all hover:bg-black/70 pointer-events-auto"
+                title="Undo last swipe"
+              >
+                ↩
+              </button>
+            )}
+
+            {/* Info icon — top right */}
+            <div className="absolute top-3 right-3 z-10 w-9 h-9 rounded-full bg-black/50 backdrop-blur-md flex items-center justify-center text-white/65 text-sm select-none pointer-events-none">
+              ⓘ
             </div>
           </motion.div>
 
-          {/* Back face */}
+          {/* ── BACK FACE — scrollable detail view ── */}
           <motion.div
-            className="absolute inset-0 bg-dark-card rounded-2xl border border-dark-border shadow-2xl overflow-hidden"
+            className="absolute inset-0 rounded-3xl overflow-hidden"
+            style={{
+              backfaceVisibility: 'hidden',
+              transformStyle: 'preserve-3d',
+              background: 'linear-gradient(160deg, #0f0e1f 0%, #1a192f 60%, #0f0e1f 100%)',
+              boxShadow: cardShadow,
+              border: '1px solid rgba(255,255,255,0.07)',
+            }}
             animate={{ rotateY: flipped ? 360 : 180 }}
-            transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
-            style={{ backfaceVisibility: 'hidden', transformStyle: 'preserve-3d' }}
+            transition={{ duration: 0.42, ease: [0.4, 0, 0.2, 1] }}
           >
-            <div ref={backScrollRef} className="p-5 h-full overflow-y-auto space-y-4">
-              <h2 className="text-xl font-bold leading-tight">{card.title} <span className="text-gray-500 font-normal text-base">({card.year})</span></h2>
+            {/* Subtle poster blur as back background */}
+            {card.posterPath && (
+              <img
+                src={card.posterPath}
+                aria-hidden="true"
+                className="absolute inset-0 w-full h-full object-cover opacity-[0.06] blur-2xl scale-110 pointer-events-none"
+                draggable={false}
+              />
+            )}
 
-              <div className="flex gap-3 flex-wrap">
-                <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
-                  <div className="text-yellow-400 text-lg font-bold">{card.voteAverage.toFixed(1)}</div>
-                  <div className="mt-0.5"><span className="bg-[#F5C518] text-black text-[9px] font-extrabold px-1 py-0.5 rounded leading-none">IMDb</span></div>
-                </div>
+            <div ref={backScrollRef} className="relative p-5 h-full overflow-y-auto space-y-4">
+              <h2 className="text-xl font-black leading-tight tracking-tight">
+                {card.title}{' '}
+                <span className="text-gray-500 font-normal text-base">({card.year})</span>
+              </h2>
+
+              {/* Stats grid */}
+              <div className="flex gap-2 flex-wrap">
+                {card.voteAverage > 0 && (
+                  <div className="bg-white/5 border border-white/8 rounded-xl px-3 py-2 text-center min-w-[58px]">
+                    <div className="text-yellow-400 text-lg font-black">{card.voteAverage.toFixed(1)}</div>
+                    <div className="mt-0.5"><span className="bg-[#F5C518] text-black text-[8px] font-extrabold px-1 py-0.5 rounded leading-none">IMDb</span></div>
+                  </div>
+                )}
                 {card.rottenTomatoesScore !== null && (
-                  <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
-                    <div className="text-red-400 text-lg font-bold">{card.rottenTomatoesScore}%</div>
-                    <div className="text-xs text-gray-500">RT</div>
+                  <div className="bg-white/5 border border-white/8 rounded-xl px-3 py-2 text-center min-w-[58px]">
+                    <div className="text-red-400 text-lg font-black">{card.rottenTomatoesScore}%</div>
+                    <div className="text-[10px] text-gray-500 mt-0.5">RT</div>
                   </div>
                 )}
                 {card.rottenTomatoesScore === null && card.metacriticScore !== null && (
-                  <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
-                    <div className="text-yellow-400 text-lg font-bold">{card.metacriticScore}</div>
-                    <div className="text-xs text-gray-500">MC</div>
+                  <div className="bg-white/5 border border-white/8 rounded-xl px-3 py-2 text-center min-w-[58px]">
+                    <div className="text-yellow-300 text-lg font-black">{card.metacriticScore}</div>
+                    <div className="text-[10px] text-gray-500 mt-0.5">MC</div>
                   </div>
                 )}
                 {card.runtime && (
-                  <div className="bg-dark-surface rounded-lg px-3 py-2 text-center min-w-[56px]">
-                    <div className="text-lg font-bold">
-                      {card.runtime >= 60
-                        ? `${Math.floor(card.runtime / 60)}h ${card.runtime % 60}m`
-                        : `${card.runtime}m`}
+                  <div className="bg-white/5 border border-white/8 rounded-xl px-3 py-2 text-center min-w-[58px]">
+                    <div className="text-white text-base font-black">
+                      {card.runtime >= 60 ? `${Math.floor(card.runtime / 60)}h ${card.runtime % 60}m` : `${card.runtime}m`}
                     </div>
-                    <div className="text-xs text-gray-500">Runtime</div>
+                    <div className="text-[10px] text-gray-500 mt-0.5">Runtime</div>
                   </div>
                 )}
               </div>
 
               {card.contentRating && (
-                <span className="inline-block px-2 py-1 bg-dark-surface border border-dark-border rounded text-xs font-bold">
+                <span className="inline-block px-2.5 py-1 bg-white/8 border border-white/10 rounded-lg text-xs font-bold text-white/70">
                   {card.contentRating}
                 </span>
               )}
 
+              {/* Genres */}
+              <div className="flex flex-wrap gap-1">
+                {card.genres.map(g => (
+                  <span key={g} className="px-2.5 py-0.5 bg-white/8 border border-white/10 rounded-full text-xs text-gray-300 font-medium">{g}</span>
+                ))}
+              </div>
+
               <p className="text-sm text-gray-300 leading-relaxed">{card.overview}</p>
 
               {card.cast.length > 0 && (
-                <p className="text-sm"><span className="text-gray-500">Starring: </span>{card.cast.join(', ')}</p>
+                <p className="text-sm"><span className="text-gray-500 font-medium">Starring </span>{card.cast.join(', ')}</p>
               )}
               {card.director && (
-                <p className="text-sm"><span className="text-gray-500">Directed by: </span>{card.director}</p>
+                <p className="text-sm"><span className="text-gray-500 font-medium">Directed by </span>{card.director}</p>
+              )}
+
+              {card.providers.length > 0 && (
+                <StreamingLogos providers={card.providers} searchTitle={card.title} />
               )}
 
               {card.trailerKey && (
@@ -310,14 +331,14 @@ export default function SwipeCard({
                   href={`https://www.youtube.com/watch?v=${card.trailerKey}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 rounded-lg text-sm font-medium transition-colors"
+                  className="inline-flex items-center gap-2 px-4 py-2.5 bg-gradient-to-r from-primary to-accent-orange rounded-xl text-sm font-bold transition-opacity hover:opacity-90"
                   onClick={e => e.stopPropagation()}
                 >
                   ▶ Watch Trailer
                 </a>
               )}
 
-              <p className="text-xs text-gray-600 text-center pb-2">Tap to flip back ↕</p>
+              <p className="text-xs text-gray-600 text-center pb-2">Tap anywhere to flip back</p>
             </div>
           </motion.div>
         </div>

--- a/apps/web/src/components/landing/CreateGameButton.tsx
+++ b/apps/web/src/components/landing/CreateGameButton.tsx
@@ -2,25 +2,33 @@
 
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import Button from '@/components/ui/Button';
 
 export default function CreateGameButton() {
   const router = useRouter();
 
   return (
-    <motion.div
-      className="w-full"
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: 0.4 }}
+    <motion.button
+      onClick={() => router.push('/create')}
+      className="relative w-full rounded-2xl overflow-hidden font-black text-lg text-white py-5 tracking-wide"
+      style={{
+        background: 'linear-gradient(135deg, #e50914 0%, #ff4b2b 50%, #ff6b35 100%)',
+        boxShadow: '0 4px 32px rgba(229,9,20,0.45), 0 1px 0 rgba(255,255,255,0.12) inset',
+      }}
+      whileTap={{ scale: 0.97 }}
+      whileHover={{ scale: 1.01 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 22 }}
     >
-      <Button
-        size="lg"
-        onClick={() => router.push('/create')}
-        className="w-full text-lg py-4 rounded-2xl"
-      >
-        Create Game
-      </Button>
-    </motion.div>
+      {/* Shimmer sweep */}
+      <motion.div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background: 'linear-gradient(105deg, transparent 40%, rgba(255,255,255,0.15) 50%, transparent 60%)',
+          backgroundSize: '200% 100%',
+        }}
+        animate={{ backgroundPosition: ['200% 0', '-100% 0'] }}
+        transition={{ duration: 2.5, repeat: Infinity, ease: 'linear', repeatDelay: 1.5 }}
+      />
+      Create Game
+    </motion.button>
   );
 }

--- a/apps/web/src/components/landing/JoinGameForm.tsx
+++ b/apps/web/src/components/landing/JoinGameForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { connectSocket } from '@/lib/socket';
 
 export default function JoinGameForm() {
@@ -14,82 +14,71 @@ export default function JoinGameForm() {
   const handleJoin = () => {
     const trimmed = code.trim().toUpperCase();
     if (trimmed.length !== 5 || checking) return;
-
     setError(null);
     setChecking(true);
-
     const socket = connectSocket();
-
     const doCheck = () => {
       socket.emit('checkRoom', trimmed, (response: any) => {
         setChecking(false);
         if ('error' in response) {
           setError(response.error);
         } else {
-          // Room verified — navigate with flag so join page skips its own check
           router.push(`/join/${trimmed}?v=1`);
         }
       });
     };
-
-    if (socket.connected) {
-      doCheck();
-    } else {
-      socket.once('connect', doCheck);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') handleJoin();
+    if (socket.connected) doCheck();
+    else socket.once('connect', doCheck);
   };
 
   const ready = code.trim().length === 5;
 
   return (
-    <motion.div
-      className="mt-4 w-full"
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: 0.5 }}
-    >
-      <div className="flex gap-3">
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-2">
+        {/* Code input */}
         <input
           value={code}
-          onChange={e => {
-            setCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''));
-            setError(null);
-          }}
-          onKeyDown={handleKeyDown}
+          onChange={e => { setCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '')); setError(null); }}
+          onKeyDown={e => e.key === 'Enter' && handleJoin()}
           placeholder="ENTER CODE"
           maxLength={5}
           spellCheck={false}
           autoComplete="off"
-          className="
-            flex-1 min-w-0
-            bg-dark-surface border border-dark-border
-            rounded-xl px-4 py-3
-            text-center font-mono text-xl tracking-[0.25em] text-white placeholder:text-gray-600 placeholder:tracking-normal placeholder:text-base
-            focus:outline-none focus:border-primary transition-colors
-          "
+          className="flex-1 min-w-0 bg-dark-surface/80 border border-dark-border rounded-xl px-4 py-4 text-center font-mono text-xl tracking-[0.35em] text-white placeholder:text-gray-700 placeholder:tracking-normal placeholder:text-sm focus:outline-none focus:border-primary/60 focus:bg-dark-surface transition-all"
         />
-        <button
+
+        {/* Join button */}
+        <motion.button
           onClick={handleJoin}
           disabled={!ready || checking}
-          className="
-            px-6 py-3 rounded-xl font-semibold text-sm
-            transition-all duration-150
-            bg-primary text-white
-            hover:bg-primary/90 active:scale-95
-            disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-primary
-            shrink-0
-          "
+          className="px-6 py-4 rounded-xl font-bold text-sm text-white shrink-0 transition-all"
+          style={{
+            background: ready
+              ? 'linear-gradient(135deg, #1a1939, #2d2b6e)'
+              : undefined,
+            backgroundColor: ready ? undefined : '#13122a',
+            border: ready ? '1px solid rgba(229,9,20,0.4)' : '1px solid rgba(45,43,78,0.6)',
+            opacity: ready ? 1 : 0.45,
+          }}
+          whileTap={ready ? { scale: 0.95 } : {}}
         >
           {checking ? '…' : 'Join'}
-        </button>
+        </motion.button>
       </div>
-      {error && (
-        <p className="mt-2 text-center text-sm text-accent-red">{error}</p>
-      )}
-    </motion.div>
+
+      <AnimatePresence>
+        {error && (
+          <motion.p
+            className="text-center text-sm text-accent-red font-medium"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+          >
+            {error}
+          </motion.p>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }


### PR DESCRIPTION
### SwipeCard — full-bleed cinematic redesign
The biggest change: poster now fills the entire card (object-cover), with a rich dark gradient overlay at the bottom carrying all the info. Tinder/dating-app style.

- Poster fills full card height, object-cover
- Top vignette (subtle black fade down) keeps undo/info icons readable
- Bottom overlay: badges (film/series, age rating) → title → year → IMDb/RT/MC → genre chips → streaming providers
- Back face has a subtle blurred poster as background texture
- Bigger border radius (rounded-3xl), stronger drop shadow
- Front/back faces use `absolute inset-0` properly inside a `relative` perspective wrapper

### Home Page — cleaner and bolder
- Logo massive (fluid `clamp(3rem, 16vw, 4.5rem)`), no HeroSection wrapper
- Tagline: uppercase tracking, smaller
- No card/panel wrapper — actions sit directly on the dark atmosphere
- Three breathing ambient blobs (red, violet, orange) independently animated

### CreateGameButton — premium shimmer CTA
- Full-width gradient button (red → orange)
- Sweeping shimmer animation loops on repeat
- Stronger shadow glow

### JoinGameForm — bolder
- Larger input (py-4), wide letter-spacing
- Join button visually responds to readiness state