### PR TITLE
fix: shimmer, atmospheric bg, button fill reset, card overlay, timer strip

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -79,6 +79,7 @@ export default function GamePage() {
     const tmdbId = titlePool[currentCardIndex].tmdbId;
 
     soundForDecision(decision);
+    setDragDirection(null); // clear button highlight immediately
     socket.emit('submitSwipe', tmdbId, decision);
     recordSwipe({ tmdbId, decision, timestamp: Date.now() });
     setFlipped(false);
@@ -92,7 +93,7 @@ export default function GamePage() {
         navigator.vibrate?.(50);
       }
     } catch {}
-  }, [socket, titlePool, currentCardIndex, recordSwipe, soundForDecision]);
+  }, [socket, titlePool, currentCardIndex, recordSwipe, soundForDecision, setDragDirection]);
 
   const handleUndo = useCallback(() => {
     const undone = undoLastSwipe();
@@ -128,7 +129,7 @@ export default function GamePage() {
   const otherPlayers = room.players.filter(p => p.id !== playerId);
 
   return (
-    <main className="flex flex-col overflow-hidden" style={{ height: gameHeight, touchAction: 'pan-y', background: '#08080f' }}>
+    <main className="flex flex-col overflow-hidden" style={{ height: gameHeight, touchAction: 'pan-y' }}>
       <TutorialOverlay onDismiss={() => setShowTutorial(false)} forceShow={showTutorial} />
       {/* Header */}
       <header className="flex items-center justify-between px-4 py-2.5 border-b border-dark-border bg-dark/90 backdrop-blur-md">
@@ -143,16 +144,14 @@ export default function GamePage() {
         {/* Progress */}
         <ProgressBar current={currentCardIndex} total={titlePool.length} />
 
-        {/* Timer */}
+        {/* Timer — sits flush under progress bar as a thin accent strip */}
         {room.settings.timerSeconds && !isFinished && (
-          <div className="mt-2">
-            <TimerBar
-              seconds={room.settings.timerSeconds}
-              isPaused={flipped}
-              onExpired={handleTimerExpired}
-              cardKey={currentCardIndex}
-            />
-          </div>
+          <TimerBar
+            seconds={room.settings.timerSeconds}
+            isPaused={flipped}
+            onExpired={handleTimerExpired}
+            cardKey={currentCardIndex}
+          />
         )}
 
         {/* Card Stack */}

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -48,7 +48,7 @@ export default function LobbyPage() {
   };
 
   return (
-    <main className="min-h-screen bg-dark">
+    <main className="min-h-screen">
       {/* Frosted glass header */}
       <header className="flex items-center justify-between px-4 py-3 border-b border-dark-border bg-dark/90 backdrop-blur-md sticky top-0 z-20">
         <Logo size="sm" />

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -102,7 +102,7 @@ export default function ResultsPage() {
   const waitingForResults = gameOver && !winner && !isRanking && !noMatches;
 
   return (
-    <main className="min-h-screen bg-dark pb-36">
+    <main className="min-h-screen pb-36">
       <header className="flex items-center px-4 py-3 border-b border-dark-border bg-dark/90 backdrop-blur-md sticky top-0 z-20">
         <Logo size="sm" />
       </header>

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -168,8 +168,11 @@ export default function SwipeCard({
             {/* Top vignette — keeps controls readable */}
             <div className="absolute inset-x-0 top-0 h-28 bg-gradient-to-b from-black/70 via-black/20 to-transparent pointer-events-none" />
 
-            {/* Bottom gradient + info overlay */}
-            <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/98 via-black/80 to-transparent pt-20 pb-4 px-4 pointer-events-none">
+            {/* Bottom gradient + info overlay — strong multi-stop for full readability */}
+            <div
+              className="absolute inset-x-0 bottom-0 pb-4 px-4 pointer-events-none"
+              style={{ paddingTop: '6rem', background: 'linear-gradient(to top, rgba(0,0,0,1) 0%, rgba(0,0,0,0.98) 30%, rgba(0,0,0,0.88) 55%, rgba(0,0,0,0.45) 75%, transparent 92%)' }}
+            >
               {/* Badges row */}
               <div className="flex items-center gap-2 mb-2">
                 <span className="text-[10px] font-bold text-white/60 bg-white/10 backdrop-blur-sm px-2 py-0.5 rounded-full tracking-wide uppercase">
@@ -183,7 +186,7 @@ export default function SwipeCard({
               </div>
 
               {/* Title */}
-              <h2 className="text-white font-black leading-tight tracking-tight" style={{ fontSize: card.title.length > 28 ? '1.1rem' : '1.35rem' }}>
+              <h2 className="text-white font-black leading-tight tracking-tight" style={{ fontSize: card.title.length > 28 ? '1.1rem' : '1.35rem', textShadow: '0 2px 12px rgba(0,0,0,0.9)' }}>
                 {card.title}
               </h2>
               <p className="text-white/45 text-sm font-medium mt-0.5">{card.year}</p>

--- a/apps/web/src/components/game/TimerBar.tsx
+++ b/apps/web/src/components/game/TimerBar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { motion } from 'framer-motion';
 
 interface TimerBarProps {
   seconds: number;
@@ -14,46 +13,37 @@ export default function TimerBar({ seconds, isPaused, onExpired, cardKey }: Time
   const [timeLeft, setTimeLeft] = useState(seconds);
   const intervalRef = useRef<NodeJS.Timeout>();
 
-  useEffect(() => {
-    setTimeLeft(seconds);
-  }, [cardKey, seconds]);
+  useEffect(() => { setTimeLeft(seconds); }, [cardKey, seconds]);
 
   useEffect(() => {
     if (isPaused) {
       if (intervalRef.current) clearInterval(intervalRef.current);
       return;
     }
-
     intervalRef.current = setInterval(() => {
       setTimeLeft(prev => {
-        if (prev <= 0.1) {
-          clearInterval(intervalRef.current);
-          onExpired();
-          return 0;
-        }
+        if (prev <= 0.1) { clearInterval(intervalRef.current); onExpired(); return 0; }
         return prev - 0.1;
       });
     }, 100);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
   }, [isPaused, cardKey, onExpired]);
 
   const pct = (timeLeft / seconds) * 100;
-  const color = pct > 60 ? 'bg-accent-green' : pct > 30 ? 'bg-yellow-500' : 'bg-accent-red';
+  const urgent = pct <= 30;
 
   return (
-    <div className="w-full">
-      <div className="h-2 bg-dark-border rounded-full overflow-hidden">
-        <motion.div
-          className={`h-full rounded-full ${color}`}
-          style={{ width: `${pct}%` }}
-          transition={{ duration: 0.1 }}
+    <div className="w-full mt-0.5">
+      {/* Thin accent strip — lives directly under the progress bar as one visual unit */}
+      <div className="h-[3px] bg-dark-border/50 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-100 ${urgent ? 'bg-accent-red' : 'bg-accent-gold'}`}
+          style={{ width: `${pct}%`, boxShadow: urgent ? '0 0 6px rgba(255,23,68,0.8)' : '0 0 4px rgba(255,215,0,0.5)' }}
         />
       </div>
-      {timeLeft <= 3 && timeLeft > 0 && (
-        <p className="text-center text-accent-red text-xs mt-1 animate-pulse">
+      {/* Urgent countdown text only in last 5s */}
+      {timeLeft <= 5 && timeLeft > 0 && (
+        <p className="text-right text-[11px] text-accent-red font-bold mt-0.5 animate-pulse tabular-nums">
           {Math.ceil(timeLeft)}s
         </p>
       )}

--- a/apps/web/src/components/landing/CreateGameButton.tsx
+++ b/apps/web/src/components/landing/CreateGameButton.tsx
@@ -18,16 +18,17 @@ export default function CreateGameButton() {
       whileHover={{ scale: 1.01 }}
       transition={{ type: 'spring', stiffness: 400, damping: 22 }}
     >
-      {/* Shimmer sweep */}
+      {/* Shimmer sweep — translateX for seamless loop (no flicker) */}
       <motion.div
-        className="absolute inset-0 pointer-events-none"
-        style={{
-          background: 'linear-gradient(105deg, transparent 40%, rgba(255,255,255,0.15) 50%, transparent 60%)',
-          backgroundSize: '200% 100%',
-        }}
-        animate={{ backgroundPosition: ['200% 0', '-100% 0'] }}
-        transition={{ duration: 2.5, repeat: Infinity, ease: 'linear', repeatDelay: 1.5 }}
-      />
+        className="absolute inset-0 pointer-events-none overflow-hidden rounded-2xl"
+      >
+        <motion.div
+          className="absolute inset-y-0 w-1/2"
+          style={{ background: 'linear-gradient(105deg, transparent 0%, rgba(255,255,255,0.18) 50%, transparent 100%)' }}
+          animate={{ x: ['-100%', '300%'] }}
+          transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut', repeatDelay: 2 }}
+        />
+      </motion.div>
       Create Game
     </motion.button>
   );


### PR DESCRIPTION
Five fixes from user feedback:

**1. Shimmer no longer flickers**
Switched from animating `backgroundPosition` (which jumps at cycle boundary) to translating a shimmer div from `-100%` to `300%` — fully smooth loop.

**2. Background atmospheric gradient now visible**
Removed `bg-dark` (solid #08080f) and inline `background:` overrides from all page `<main>` elements. The body's `background-attachment: fixed` gradient (red bloom + violet depth) now shows through on every page.

**3. Button fill resets after swipe**
Added `setDragDirection(null)` at the start of `handleSwipe` so the filled button immediately clears when the swipe is committed.

**4. Card text overlay is clearly readable**
Replaced the single `bg-gradient-to-t from-black/98` with a custom multi-stop gradient:
`linear-gradient(to top, rgba(0,0,0,1) 0%, 0.98 at 30%, 0.88 at 55%, 0.45 at 75%, transparent at 92%)`
Added `text-shadow` on the title. The poster's own text no longer bleeds through.

**5. Timer bar no longer a second fat bar**
TimerBar rewritten as a thin 3px accent strip that sits flush under the progress bar — same visual unit, not a competing element. Only shows urgent countdown text in the last 5s.