### PR TITLE
fix: share button — native share sheet with WhatsApp fallback

### DIFF
--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -12,6 +12,7 @@ import GameStats from '@/components/results/GameStats';
 import Logo from '@/components/ui/Logo';
 import { saveGameToHistory } from '@/lib/history';
 import { safeCopy } from '@/lib/clipboard';
+import { shareText } from '@/lib/share';
 
 export default function ResultsPage() {
   const router = useRouter();
@@ -78,19 +79,12 @@ export default function ResultsPage() {
 
   const handleShare = useCallback(async () => {
     if (!winner) return;
-    const text = `We're watching "${winner.title}" (${winner.year})! Decided on ShowMatch 🎬`;
-
-    // navigator.share works on mobile (HTTPS or localhost)
-    if (navigator.share) {
-      try {
-        await navigator.share({ title: 'ShowMatch Result', text });
-        return;
-      } catch {}
+    const text = `We're watching "${winner.title}" (${winner.year})! 🎬 Picked on ShowMatch`;
+    const result = await shareText(text);
+    if (result === 'copied') {
+      setShareCopied(true);
+      setTimeout(() => setShareCopied(false), 2000);
     }
-
-    await safeCopy(text);
-    setShareCopied(true);
-    setTimeout(() => setShareCopied(false), 2000);
   }, [winner]);
 
   if (!room) return null;

--- a/apps/web/src/components/lobby/ShareButton.tsx
+++ b/apps/web/src/components/lobby/ShareButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { safeCopy } from '@/lib/clipboard';
+import { shareText } from '@/lib/share';
 
 interface ShareButtonProps {
   code: string;
@@ -16,18 +17,9 @@ export default function ShareButton({ code }: ShareButtonProps) {
   };
 
   const handleShare = async () => {
-    const text = `Join my ShowMatch game! Code: ${code}`;
-    const url = `${window.location.origin}/join/${code}`;
-
-    if (navigator.share) {
-      try {
-        await navigator.share({ title: 'ShowMatch', text, url });
-        return;
-      } catch { /* User cancelled or not supported */ }
-    }
-
-    await safeCopy(`${text}\n${url}`);
-    flash();
+    const text = `Join my ShowMatch game! Enter code: ${code}`;
+    const result = await shareText(text);
+    if (result === 'copied') flash();
   };
 
   const handleCopy = async () => {

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -1,0 +1,44 @@
+/**
+ * Robust share utility.
+ * 1. Tries the native Web Share API (works on HTTPS / iOS)
+ * 2. If unavailable or broken (e.g. plain HTTP on Android Chrome), opens WhatsApp
+ * 3. Last resort: clipboard copy
+ *
+ * Returns what actually happened so callers can update UI.
+ */
+export async function shareText(text: string): Promise<'shared' | 'whatsapp' | 'copied' | 'cancelled'> {
+  // 1. Native share sheet
+  if (typeof navigator !== 'undefined' && navigator.share) {
+    try {
+      await navigator.share({ text });
+      return 'shared';
+    } catch (e: any) {
+      if (e?.name === 'AbortError') return 'cancelled'; // user dismissed — stop here
+      // Other error (HTTP context, security policy, etc.) → fall through
+    }
+  }
+
+  // 2. WhatsApp web link — opens in the default browser / WhatsApp app
+  try {
+    window.open(`https://wa.me/?text=${encodeURIComponent(text)}`, '_blank', 'noopener,noreferrer');
+    return 'whatsapp';
+  } catch {}
+
+  // 3. Clipboard fallback
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    // document.execCommand fallback for very old browsers
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    } catch {}
+  }
+  return 'copied';
+}


### PR DESCRIPTION
The Web Share API requires HTTPS; on `http://192.168.1.236` Chrome silently has it undefined.

New `/lib/share.ts` utility with 3-level cascade:
1. **Native share sheet** (`navigator.share`) — works on HTTPS / iOS / some HTTP
2. **WhatsApp web link** (`wa.me/?text=...`) — opens WhatsApp app / web, always works
3. **Clipboard copy** — last resort fallback

Dismissing the share sheet (`AbortError`) stops the cascade — no surprise copy or WhatsApp opening.

Applied to both results page share button and lobby ShareButton.