### PR TITLE
fix: card swipeable when viewing info side

### DIFF
--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -267,7 +267,7 @@ export default function SwipeCard({
               />
             )}
 
-            <div ref={backScrollRef} className="relative p-5 h-full overflow-y-auto space-y-4">
+            <div ref={backScrollRef} className="relative p-5 h-full overflow-y-auto space-y-4" style={{ touchAction: 'pan-y', overscrollBehavior: 'none' }}>
               <h2 className="text-xl font-black leading-tight tracking-tight">
                 {card.title}{' '}
                 <span className="text-gray-500 font-normal text-base">({card.year})</span>


### PR DESCRIPTION
Root cause: the back face `overflow-y-auto` scroll container was absorbing all touch events, including horizontal ones that should trigger Framer Motion's `drag='x'` handler.

Fix: add `touchAction: 'pan-y'` directly to the scroll container div (`backScrollRef`). This tells the browser to only use this element for vertical scroll (panning) and pass horizontal touch movements up the tree to Framer Motion.

Also added `overscrollBehavior: 'none'` to prevent rubber-band overscroll at the content boundaries from interfering with swipe detection.