### PR TITLE
fix: card back face scroll

### DIFF
--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -124,8 +124,8 @@ export default function SwipeCard({
       <motion.div
         className="relative cursor-grab active:cursor-grabbing select-none h-full"
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        style={{ x, y, rotate, touchAction: flipped ? 'pan-y' : 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', willChange: 'transform' } as any}
-        drag={!preview && isTop && !exiting ? (flipped ? 'x' : true) : false}
+        style={{ x, y, rotate, touchAction: flipped ? 'auto' : 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', willChange: 'transform' } as any}
+        drag={!preview && isTop && !exiting && !flipped ? true : false}
         dragElastic={0.8}
         onDragEnd={isTop ? handleDragEnd : undefined}
         onClick={handleTap}


### PR DESCRIPTION
When flipped, drag is now fully disabled (was 'x') and touchAction set to 'auto'. Framer Motion no longer competes with the browser for touch events, so vertical scroll on the info panel works naturally.