### PR TITLE
fix: swipe stamps centered on card

### DIFF
--- a/apps/web/src/components/game/CardOverlay.tsx
+++ b/apps/web/src/components/game/CardOverlay.tsx
@@ -11,71 +11,83 @@ interface CardOverlayProps {
 }
 
 export default function CardOverlay({ likeOpacity, nopeOpacity, superLikeOpacity, x, y }: CardOverlayProps) {
-  // Subtle color wash that grows as the card is dragged
-  const greenWash  = useTransform(x, [0,   180], [0, 0.22]);
-  const redWash    = useTransform(x, [-180, 0],  [0.22, 0]);
-  const goldWash   = useTransform(y, [-180, 0],  [0.22, 0]);
+  const greenWash = useTransform(x, [0,    180], [0, 0.22]);
+  const redWash   = useTransform(x, [-180,   0], [0.22, 0]);
+  const goldWash  = useTransform(y, [-180,   0], [0.22, 0]);
+
+  const stampBase: React.CSSProperties = {
+    fontWeight: 900,
+    letterSpacing: '0.15em',
+    fontSize: '1.25rem',
+    textTransform: 'uppercase',
+    border: '3px solid',
+    borderRadius: '0.75rem',
+    padding: '0.375rem 0.875rem',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.375rem',
+  };
 
   return (
     <>
-      {/* Green background wash — like */}
-      <motion.div
-        className="absolute inset-0 z-10 rounded-2xl pointer-events-none"
-        style={{ opacity: greenWash, background: 'rgba(0, 200, 83, 1)' }}
-      />
-      {/* Red background wash — nope */}
-      <motion.div
-        className="absolute inset-0 z-10 rounded-2xl pointer-events-none"
-        style={{ opacity: redWash, background: 'rgba(255, 23, 68, 1)' }}
-      />
-      {/* Gold background wash — superlike */}
+      {/* Color washes */}
+      <motion.div className="absolute inset-0 z-10 rounded-3xl pointer-events-none"
+        style={{ opacity: greenWash, background: 'rgba(0,200,83,1)' }} />
+      <motion.div className="absolute inset-0 z-10 rounded-3xl pointer-events-none"
+        style={{ opacity: redWash, background: 'rgba(255,23,68,1)' }} />
       {superLikeOpacity && (
-        <motion.div
-          className="absolute inset-0 z-10 rounded-2xl pointer-events-none"
-          style={{ opacity: goldWash, background: 'rgba(255, 215, 0, 1)' }}
-        />
+        <motion.div className="absolute inset-0 z-10 rounded-3xl pointer-events-none"
+          style={{ opacity: goldWash, background: 'rgba(255,215,0,1)' }} />
       )}
 
-      {/* ❤️ LIKE stamp — top right, tilted left */}
+      {/* ❤️ LIKE — centered */}
       <motion.div
-        className="absolute top-5 right-4 z-20 pointer-events-none"
+        className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none"
         style={{ opacity: likeOpacity }}
       >
-        <div
-          className="flex items-center gap-1.5 border-[3px] border-accent-green text-accent-green px-3 py-1.5 rounded-xl font-extrabold tracking-widest"
-          style={{ transform: 'rotate(-15deg)', textShadow: '0 0 20px rgba(0,200,83,0.8)', boxShadow: '0 0 20px rgba(0,200,83,0.4)' }}
-        >
-          <span className="text-2xl">❤️</span>
-          <span className="text-xl uppercase">LIKE</span>
+        <div style={{
+          ...stampBase,
+          transform: 'rotate(-12deg)',
+          borderColor: '#00c853',
+          color: '#00c853',
+          textShadow: '0 0 20px rgba(0,200,83,0.9)',
+          boxShadow: '0 0 24px rgba(0,200,83,0.5)',
+        }}>
+          <span style={{ fontSize: '1.5rem' }}>❤️</span> LIKE
         </div>
       </motion.div>
 
-      {/* ✕ NOPE stamp — top left, tilted right */}
+      {/* ✕ NOPE — centered */}
       <motion.div
-        className="absolute top-5 left-4 z-20 pointer-events-none"
+        className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none"
         style={{ opacity: nopeOpacity }}
       >
-        <div
-          className="flex items-center gap-1.5 border-[3px] border-accent-red text-accent-red px-3 py-1.5 rounded-xl font-extrabold tracking-widest"
-          style={{ transform: 'rotate(15deg)', textShadow: '0 0 20px rgba(255,23,68,0.8)', boxShadow: '0 0 20px rgba(255,23,68,0.4)' }}
-        >
-          <span className="text-xl font-black">✕</span>
-          <span className="text-xl uppercase">NOPE</span>
+        <div style={{
+          ...stampBase,
+          transform: 'rotate(12deg)',
+          borderColor: '#ff1744',
+          color: '#ff1744',
+          textShadow: '0 0 20px rgba(255,23,68,0.9)',
+          boxShadow: '0 0 24px rgba(255,23,68,0.5)',
+        }}>
+          <span style={{ fontSize: '1.3rem', fontWeight: 900 }}>✕</span> NOPE
         </div>
       </motion.div>
 
-      {/* ⭐ SUPER LIKE stamp — top center, no tilt */}
+      {/* ⭐ SUPER LIKE — centered */}
       {superLikeOpacity && (
         <motion.div
-          className="absolute top-5 inset-x-0 z-20 flex justify-center pointer-events-none"
+          className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none"
           style={{ opacity: superLikeOpacity }}
         >
-          <div
-            className="flex items-center gap-1.5 border-[3px] border-accent-gold text-accent-gold px-3 py-1.5 rounded-xl font-extrabold tracking-widest"
-            style={{ textShadow: '0 0 20px rgba(255,215,0,0.8)', boxShadow: '0 0 20px rgba(255,215,0,0.4)' }}
-          >
-            <span className="text-2xl">⭐</span>
-            <span className="text-xl uppercase">SUPER</span>
+          <div style={{
+            ...stampBase,
+            borderColor: '#ffd700',
+            color: '#ffd700',
+            textShadow: '0 0 20px rgba(255,215,0,0.9)',
+            boxShadow: '0 0 24px rgba(255,215,0,0.5)',
+          }}>
+            <span style={{ fontSize: '1.5rem' }}>⭐</span> SUPER
           </div>
         </motion.div>
       )}


### PR DESCRIPTION
Moved LIKE/NOPE/SUPER LIKE stamps from top corners to the vertical and horizontal center of the card. Since only one shows at a time and the card center is the last part to leave the screen during a swipe, the stamp is always visible.