### PR TITLE
feat: TV series year range

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -122,11 +122,12 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
   const id = title.tmdbId;
 
   try {
-    const [creditsRes, videosRes, providersRes, externalRes] = await Promise.allSettled([
+    const [creditsRes, videosRes, providersRes, externalRes, detailRes] = await Promise.allSettled([
       tmdbFetch(`/${type}/${id}/credits`),
       tmdbFetch(`/${type}/${id}/videos`),
       tmdbFetch(`/${type}/${id}/watch/providers`),
       tmdbFetch(`/${type}/${id}/external_ids`),
+      type === 'tv' ? tmdbFetch(`/tv/${id}`) : Promise.resolve(null as any),
     ]);
 
     // Credits
@@ -175,6 +176,15 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
           }
         } catch { /* OMDB failure is non-critical */ }
       }
+    }
+
+    // TV series — end year + status
+    if (type === 'tv' && detailRes.status === 'fulfilled' && detailRes.value && detailRes.value.ok) {
+      const detail = await detailRes.value.json();
+      const lastAir = detail.last_air_date ? parseInt(detail.last_air_date.split('-')[0]) : undefined;
+      if (lastAir && lastAir !== title.year) title.endYear = lastAir;
+      const s = detail.status as string | undefined;
+      title.seriesStatus = (s === 'Ended' || s === 'Canceled') ? 'ended' : 'running';
     }
 
     // Content rating

--- a/apps/socket-server/src/types.ts
+++ b/apps/socket-server/src/types.ts
@@ -18,6 +18,8 @@ export interface TitleCard {
   mediaType: 'movie' | 'tv';
   title: string;
   year: number;
+  endYear?: number;           // TV only — last season year
+  seriesStatus?: 'running' | 'ended'; // TV only
   posterPath: string;
   overview: string;
   voteAverage: number;

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -195,10 +195,16 @@ export default function SwipeCard({
                 {card.title}
               </h2>
 
-              {/* Year + ratings on one compact line */}
+              {/* Year (range for TV) + ratings on one compact line */}
               <div className="flex items-center gap-3 mt-1 flex-wrap">
                 <span className="text-white/50 text-sm font-medium" style={{ textShadow: '0 1px 8px rgba(0,0,0,0.9)' }}>
-                  {card.year}
+                  {card.mediaType === 'tv' ? (
+                    card.seriesStatus === 'running'
+                      ? <>{card.year} – <span className="text-primary/80 font-bold">ongoing</span></>
+                      : card.endYear
+                        ? `${card.year} – ${card.endYear}`
+                        : card.year
+                  ) : card.year}
                 </span>
                 {card.voteAverage > 0 && (
                   <span className="flex items-center gap-1.5">
@@ -299,7 +305,15 @@ export default function SwipeCard({
             <div ref={backScrollRef} className="relative p-5 h-full overflow-y-auto space-y-4" style={{ touchAction: 'pan-y', overscrollBehavior: 'none' }}>
               <h2 className="text-xl font-black leading-tight tracking-tight">
                 {card.title}{' '}
-                <span className="text-gray-500 font-normal text-base">({card.year})</span>
+                <span className="text-gray-500 font-normal text-base">
+                  ({card.mediaType === 'tv'
+                    ? card.seriesStatus === 'running'
+                      ? `${card.year} – ongoing`
+                      : card.endYear
+                        ? `${card.year} – ${card.endYear}`
+                        : card.year
+                    : card.year})
+                </span>
               </h2>
 
               {/* Stats grid */}

--- a/apps/web/src/types/game.ts
+++ b/apps/web/src/types/game.ts
@@ -18,6 +18,8 @@ export interface TitleCard {
   mediaType: 'movie' | 'tv';
   title: string;
   year: number;
+  endYear?: number;           // TV only — last season year
+  seriesStatus?: 'running' | 'ended'; // TV only
   posterPath: string;
   overview: string;
   voteAverage: number;


### PR DESCRIPTION
For TV shows, display full year span instead of just the start year.

- Added endYear and seriesStatus (running/ended) fields to TitleCard
- tmdb.ts fetches /tv/{id} in the parallel enrichment batch to get last_air_date and status
- Returning Series / In Production → seriesStatus: running → displays '2022 – ongoing' in red
- Ended / Canceled → seriesStatus: ended → displays '2018 – 2023' (or just year if same)
- Both front and back face updated