### PR TITLE
feat: TV year filter + seasons count

### DIFF
--- a/apps/socket-server/src/lib/tmdb.ts
+++ b/apps/socket-server/src/lib/tmdb.ts
@@ -178,13 +178,14 @@ async function enrichTitle(title: TitleCard, region: string): Promise<TitleCard>
       }
     }
 
-    // TV series — end year + status
+    // TV series — end year, status, seasons
     if (type === 'tv' && detailRes.status === 'fulfilled' && detailRes.value && detailRes.value.ok) {
       const detail = await detailRes.value.json();
-      const lastAir = detail.last_air_date ? parseInt(detail.last_air_date.split('-')[0]) : undefined;
+      const lastAir = detail.last_air_date ? parseInt((detail.last_air_date as string).split('-')[0]) : undefined;
       if (lastAir && lastAir !== title.year) title.endYear = lastAir;
       const s = detail.status as string | undefined;
       title.seriesStatus = (s === 'Ended' || s === 'Canceled') ? 'ended' : 'running';
+      if (detail.number_of_seasons) title.seasons = detail.number_of_seasons as number;
     }
 
     // Content rating
@@ -231,9 +232,15 @@ function buildDiscoverParams(settings: GameSettings, mediaType: 'movie' | 'tv'):
     params.set('vote_average.gte', settings.minRating.toString());
   }
 
-  const dateField = mediaType === 'movie' ? 'primary_release_date' : 'first_air_date';
-  params.set(`${dateField}.gte`, `${settings.yearRange[0]}-01-01`);
-  params.set(`${dateField}.lte`, `${settings.yearRange[1]}-12-31`);
+  if (mediaType === 'movie') {
+    params.set('primary_release_date.gte', `${settings.yearRange[0]}-01-01`);
+    params.set('primary_release_date.lte', `${settings.yearRange[1]}-12-31`);
+  } else {
+    // For TV, match any show that had episodes airing WITHIN the range —
+    // this includes long-running shows that started before the range.
+    params.set('air_date.gte', `${settings.yearRange[0]}-01-01`);
+    params.set('air_date.lte', `${settings.yearRange[1]}-12-31`);
+  }
 
   if (settings.language) {
     params.set('with_original_language', settings.language);

--- a/apps/socket-server/src/types.ts
+++ b/apps/socket-server/src/types.ts
@@ -20,6 +20,7 @@ export interface TitleCard {
   year: number;
   endYear?: number;           // TV only — last season year
   seriesStatus?: 'running' | 'ended'; // TV only
+  seasons?: number;           // TV only — number of seasons
   posterPath: string;
   overview: string;
   voteAverage: number;

--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -199,11 +199,14 @@ export default function SwipeCard({
               <div className="flex items-center gap-3 mt-1 flex-wrap">
                 <span className="text-white/50 text-sm font-medium" style={{ textShadow: '0 1px 8px rgba(0,0,0,0.9)' }}>
                   {card.mediaType === 'tv' ? (
-                    card.seriesStatus === 'running'
-                      ? <>{card.year} – <span className="text-primary/80 font-bold">ongoing</span></>
-                      : card.endYear
-                        ? `${card.year} – ${card.endYear}`
-                        : card.year
+                    <>
+                      {card.seriesStatus === 'running'
+                        ? <>{card.year} – <span className="text-primary/80 font-semibold">ongoing</span></>
+                        : card.endYear ? `${card.year} – ${card.endYear}` : card.year}
+                      {card.seasons && (
+                        <span className="text-white/35"> · {card.seasons} {card.seasons === 1 ? 'season' : 'seasons'}</span>
+                      )}
+                    </>
                   ) : card.year}
                 </span>
                 {card.voteAverage > 0 && (
@@ -314,6 +317,11 @@ export default function SwipeCard({
                         : card.year
                     : card.year})
                 </span>
+                {card.seasons && (
+                  <span className="text-gray-600 font-normal text-sm ml-1">
+                    · {card.seasons} {card.seasons === 1 ? 'season' : 'seasons'}
+                  </span>
+                )}
               </h2>
 
               {/* Stats grid */}
@@ -342,6 +350,12 @@ export default function SwipeCard({
                       {card.runtime >= 60 ? `${Math.floor(card.runtime / 60)}h ${card.runtime % 60}m` : `${card.runtime}m`}
                     </div>
                     <div className="text-[10px] text-gray-500 mt-0.5">Runtime</div>
+                  </div>
+                )}
+                {card.seasons && (
+                  <div className="bg-white/5 border border-white/8 rounded-xl px-3 py-2 text-center min-w-[58px]">
+                    <div className="text-white text-base font-black">{card.seasons}</div>
+                    <div className="text-[10px] text-gray-500 mt-0.5">{card.seasons === 1 ? 'Season' : 'Seasons'}</div>
                   </div>
                 )}
               </div>

--- a/apps/web/src/types/game.ts
+++ b/apps/web/src/types/game.ts
@@ -20,6 +20,7 @@ export interface TitleCard {
   year: number;
   endYear?: number;           // TV only — last season year
   seriesStatus?: 'running' | 'ended'; // TV only
+  seasons?: number;           // TV only — number of seasons
   posterPath: string;
   overview: string;
   voteAverage: number;


### PR DESCRIPTION
Two changes:

1. Year filter for TV: switched from first_air_date to air_date on TMDB discover. Now includes any show that had episodes airing during the selected range, not just shows that started in it.

2. Seasons count: fetched from /tv/{id} (already fetched for year range). Shown on front face inline with the year (2018–2023 · 5 seasons) and as a tile in the back face stats grid.