### PR TITLE
fix: remove player from lobby on disconnect/navigation away

### DIFF
--- a/apps/socket-server/src/state/RoomManager.ts
+++ b/apps/socket-server/src/state/RoomManager.ts
@@ -199,11 +199,12 @@ class RoomManager {
     player.connected = false;
 
     const timerKey = `${room.code}:${socketId}`;
+    // Lobby: 5s grace — no in-progress state to preserve; fast feedback for others.
     // Finished rooms: 5s grace (feels responsive, survives brief reconnects).
     // Host in active game: 15s grace — long enough to survive a brief network blip,
     //   short enough that guests don't wait forever if the host leaves for real.
-    // Other players: 60s grace (allows full reconnect mid-game).
-    const graceMs = room.status === 'finished'
+    // Other players in active game: 60s grace (allows full reconnect mid-game).
+    const graceMs = (room.status === 'lobby' || room.status === 'finished')
       ? 5_000
       : (player.isCreator ? 15_000 : 60_000);
     const timer = setTimeout(() => {

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
+import { getSocket } from '@/lib/socket';
 import FilterPanel from '@/components/lobby/FilterPanel';
 import FilterPreview from '@/components/lobby/FilterPreview';
 import PlayerList from '@/components/lobby/PlayerList';
@@ -31,6 +32,19 @@ export default function LobbyPage() {
       router.push(`/game/${room.code}`);
     }
   }, [room?.status, room?.code, router]);
+
+  // When the player navigates away (SPA or tab close) while still in the
+  // lobby, tell the server so other players see an updated list immediately.
+  // Guard: don't emit when the game starts — room.status will be 'swiping'
+  // by the time this cleanup runs (game navigation triggers before unmount).
+  useEffect(() => {
+    return () => {
+      const { room: currentRoom } = useGameStore.getState();
+      if (currentRoom?.status === 'lobby') {
+        getSocket().emit('leaveRoom');
+      }
+    };
+  }, []);
 
   if (!room) return null;
 


### PR DESCRIPTION
## Problem

When a player exits the lobby before the game starts, their name stays in the player list for everyone else — either indefinitely (SPA navigation) or for 60 seconds (browser close).

## Root Cause

Two gaps:
1. **SPA navigation** (back button, navigating to ): the socket stays connected so no disconnect event fires. The lobby page had no cleanup that emitted `leaveRoom`, so the player became a permanent ghost.
2. **Browser close / hard disconnect**: `RoomManager.handleDisconnect` applied a 60s reconnect grace period even in the lobby, where there's no in-progress swipe state worth preserving.

## Fix

**Client** (`lobby/[code]/page.tsx`): Added a `useEffect` cleanup that emits `leaveRoom` when the component unmounts while `room.status === 'lobby'`. The guard prevents false positives when the game starts — by the time the lobby unmounts, `store.startGame()` has already set `room.status = 'swiping'`.

**Server** (`RoomManager.ts`): Grace period for `lobby` status reduced from 60s → 5s. This mirrors the already-short grace for `finished` rooms, and ensures browser-close disconnects surface quickly to the rest of the lobby.

## Paths covered

| Scenario | Before | After |
|---|---|---|
| Player presses Back (SPA nav) | Stays forever | Removed immediately |
| Player closes tab/browser | Removed after 60s | Removed after 5s |
| Player clicks a Leave button (future) | Already worked | Still works |
| Game starts → lobby unmounts | N/A | No leaveRoom emitted (guarded) |