### PR TITLE
fix: show '2025 –' for running series instead of '2025 – ongoing'

### DIFF
--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -201,7 +201,7 @@ export default function SwipeCard({
                   {card.mediaType === 'tv' ? (
                     <>
                       {card.seriesStatus === 'running'
-                        ? <>{card.year} – <span className="text-primary font-bold">ongoing</span></>
+                        ? `${card.year} –`
                         : card.endYear ? `${card.year} – ${card.endYear}` : card.year}
                       {card.seasons && (
                         <span className="text-white/60"> · {card.seasons} {card.seasons === 1 ? 'season' : 'seasons'}</span>
@@ -311,7 +311,7 @@ export default function SwipeCard({
                 <span className="text-gray-500 font-normal text-base">
                   ({card.mediaType === 'tv'
                     ? card.seriesStatus === 'running'
-                      ? `${card.year} – ongoing`
+                      ? `${card.year} –`
                       : card.endYear
                         ? `${card.year} – ${card.endYear}`
                         : card.year


### PR DESCRIPTION
Replace 'ongoing' text with a trailing dash for still-running TV series.\n\nBefore: 2025 – **ongoing**\nAfter: 2025 –\n\nUpdated both front face (JSX) and back face (template string).