### PR TITLE
feat: swipe to delete individual game history entries

### DIFF
--- a/apps/web/src/components/results/GameHistory.tsx
+++ b/apps/web/src/components/results/GameHistory.tsx
@@ -1,11 +1,106 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { getGameHistory, clearGameHistory } from '@/lib/history';
+import {
+  motion, AnimatePresence,
+  animate, useMotionValue, useTransform,
+} from 'framer-motion';
+import { getGameHistory, deleteGameFromHistory, clearGameHistory } from '@/lib/history';
 import type { GameHistoryEntry } from '@/types/game';
 import Modal from '@/components/ui/Modal';
 import Button from '@/components/ui/Button';
+
+// ─── Single swipeable row ──────────────────────────────────────────────────
+
+interface RowProps {
+  entry: GameHistoryEntry;
+  onDelete: (id: string) => void;
+}
+
+function DeletableHistoryItem({ entry, onDelete }: RowProps) {
+  const x = useMotionValue(0);
+
+  // Red bg + trash icon fade in as the drag distance grows
+  const bgOpacity  = useTransform(x, [-90, -30, 0, 30, 90], [1, 0.4, 0, 0.4, 1]);
+  const iconScale  = useTransform(x, [-90, -30, 0, 30, 90], [1, 0.6, 0.4, 0.6, 1]);
+
+  const handleDragEnd = (_: unknown, info: { offset: { x: number }; velocity: { x: number } }) => {
+    const far   = Math.abs(info.offset.x) > 80;
+    const fast  = Math.abs(info.velocity.x) > 450;
+    if (far || fast) {
+      const dir = info.offset.x >= 0 ? 1 : -1;
+      // Fly card off screen, then remove from list
+      animate(x, dir * 600, { type: 'tween', duration: 0.22, ease: 'easeOut' });
+      setTimeout(() => onDelete(entry.id), 200);
+    } else {
+      // Snap back
+      animate(x, 0, { type: 'spring', stiffness: 500, damping: 38 });
+    }
+  };
+
+  return (
+    // Height-collapse wrapper — exits by collapsing to 0
+    <motion.div
+      layout
+      initial={false}
+      exit={{ height: 0, opacity: 0, marginBottom: 0 }}
+      transition={{ duration: 0.22, ease: 'easeInOut' }}
+      className="overflow-hidden"
+    >
+      {/* Red background (revealed as card slides) */}
+      <div className="relative rounded-xl overflow-hidden mb-0">
+        <motion.div
+          className="absolute inset-0 rounded-xl flex items-center justify-center gap-2"
+          style={{
+            background: 'rgba(229,9,20,0.88)',
+            opacity: bgOpacity,
+          }}
+        >
+          <motion.span style={{ scale: iconScale, fontSize: '1.3rem' }}>🗑️</motion.span>
+        </motion.div>
+
+        {/* Draggable card — sits on top of the red layer */}
+        <motion.div
+          drag="x"
+          dragMomentum={false}
+          onDragEnd={handleDragEnd}
+          style={{ x, touchAction: 'pan-y' }}
+          className="relative bg-dark-surface rounded-xl p-3 border border-dark-border cursor-grab active:cursor-grabbing select-none"
+        >
+          <div className="flex items-center gap-3">
+            {entry.winner?.posterPath && (
+              <img
+                src={entry.winner.posterPath}
+                alt={entry.winner.title}
+                className="w-10 h-14 rounded object-cover shrink-0"
+              />
+            )}
+            <div className="flex-1 min-w-0">
+              <p className="font-medium truncate" title={entry.winner?.title || 'No winner'}>
+                {entry.winner?.title || 'No winner'}
+              </p>
+              <p className="text-xs text-gray-500">
+                {new Date(entry.date).toLocaleDateString()} &middot; {entry.players.join(', ')}
+              </p>
+            </div>
+          </div>
+
+          {entry.stats.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {entry.stats.map(s => (
+                <span key={s.title} className="text-xs bg-dark-card px-2 py-0.5 rounded">
+                  {s.emoji} {s.playerName}
+                </span>
+              ))}
+            </div>
+          )}
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+}
+
+// ─── Modal with list ───────────────────────────────────────────────────────
 
 interface GameHistoryProps {
   isOpen: boolean;
@@ -17,10 +112,13 @@ export default function GameHistory({ isOpen, onClose }: GameHistoryProps) {
   const [confirmClear, setConfirmClear] = useState(false);
 
   useEffect(() => {
-    if (isOpen) {
-      setHistory(getGameHistory());
-    }
+    if (isOpen) setHistory(getGameHistory());
   }, [isOpen]);
+
+  const handleDelete = (id: string) => {
+    deleteGameFromHistory(id);
+    setHistory(prev => prev.filter(e => e.id !== id));
+  };
 
   const handleClear = () => {
     clearGameHistory();
@@ -33,43 +131,17 @@ export default function GameHistory({ isOpen, onClose }: GameHistoryProps) {
       {history.length === 0 ? (
         <p className="text-gray-500 text-center py-8">No games played yet</p>
       ) : (
-        <div className="space-y-3 max-h-[60vh] overflow-y-auto">
-          {history.map((entry) => (
-            <motion.div
-              key={entry.id}
-              className="bg-dark-surface rounded-xl p-3 border border-dark-border"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-            >
-              <div className="flex items-center gap-3">
-                {entry.winner?.posterPath && (
-                  <img
-                    src={entry.winner.posterPath}
-                    alt={entry.winner.title}
-                    className="w-10 h-14 rounded object-cover"
-                  />
-                )}
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium truncate" title={entry.winner?.title || 'No winner'}>
-                    {entry.winner?.title || 'No winner'}
-                  </p>
-                  <p className="text-xs text-gray-500">
-                    {new Date(entry.date).toLocaleDateString()} &middot; {entry.players.join(', ')}
-                  </p>
-                </div>
-              </div>
-
-              {entry.stats.length > 0 && (
-                <div className="flex flex-wrap gap-1 mt-2">
-                  {entry.stats.map(s => (
-                    <span key={s.title} className="text-xs bg-dark-card px-2 py-0.5 rounded">
-                      {s.emoji} {s.playerName}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </motion.div>
-          ))}
+        <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+          <p className="text-xs text-gray-600 text-center pb-1">Swipe left or right to delete</p>
+          <AnimatePresence mode="popLayout" initial={false}>
+            {history.map(entry => (
+              <DeletableHistoryItem
+                key={entry.id}
+                entry={entry}
+                onDelete={handleDelete}
+              />
+            ))}
+          </AnimatePresence>
         </div>
       )}
 
@@ -77,12 +149,8 @@ export default function GameHistory({ isOpen, onClose }: GameHistoryProps) {
         <div className="mt-4 pt-4 border-t border-dark-border">
           {confirmClear ? (
             <div className="flex gap-2 justify-center">
-              <Button onClick={handleClear} variant="ghost" size="sm">
-                Yes, Clear All
-              </Button>
-              <Button onClick={() => setConfirmClear(false)} variant="secondary" size="sm">
-                Cancel
-              </Button>
+              <Button onClick={handleClear} variant="ghost" size="sm">Yes, Clear All</Button>
+              <Button onClick={() => setConfirmClear(false)} variant="secondary" size="sm">Cancel</Button>
             </div>
           ) : (
             <Button onClick={() => setConfirmClear(true)} variant="ghost" size="sm" className="w-full">

--- a/apps/web/src/lib/history.ts
+++ b/apps/web/src/lib/history.ts
@@ -21,6 +21,13 @@ export function getGameHistory(): GameHistoryEntry[] {
   }
 }
 
+export function deleteGameFromHistory(id: string): void {
+  try {
+    const history = getGameHistory().filter(e => e.id !== id);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  } catch {}
+}
+
 export function clearGameHistory(): void {
   try {
     localStorage.removeItem(STORAGE_KEY);


### PR DESCRIPTION
Swipe a game history row left or right to delete it. Red background reveals behind the card as you drag, with a trash icon. Past the threshold the card flies off and the row collapses. Supports vertical scroll in the modal while dragging horizontally.