### PR TITLE
fix: background glows visible on mobile (iOS Safari fix)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -9,12 +9,7 @@
 
 body {
   color: var(--foreground);
-  background:
-    radial-gradient(ellipse at 15% 15%, rgba(229, 9, 20, 0.25) 0%, transparent 55%),
-    radial-gradient(ellipse at 85% 85%, rgba(109, 40, 217, 0.18) 0%, transparent 55%),
-    radial-gradient(ellipse at 50% 100%, rgba(229, 9, 20, 0.10) 0%, transparent 50%),
-    #08080f;
-  background-attachment: fixed;
+  background: #08080f;
   font-family: 'Inter', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -23,7 +23,25 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="min-h-screen bg-dark text-white overscroll-none">
-        <PageTransitionWrapper>{children}</PageTransitionWrapper>
+        {/* Fixed background glows — position:fixed is the only reliable way
+            to get a persistent gradient on iOS Safari (background-attachment:fixed is ignored). */}
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 0,
+            pointerEvents: 'none',
+            background: [
+              'radial-gradient(ellipse at 15% 10%,  rgba(229,9,20,0.42)   0%, transparent 55%)',
+              'radial-gradient(ellipse at 88% 88%,  rgba(109,40,217,0.30) 0%, transparent 55%)',
+              'radial-gradient(ellipse at 50% 105%, rgba(229,9,20,0.18)   0%, transparent 45%)',
+            ].join(', '),
+          }}
+        />
+        <div style={{ position: 'relative', zIndex: 1 }}>
+          <PageTransitionWrapper>{children}</PageTransitionWrapper>
+        </div>
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -39,19 +39,19 @@ export default function Home() {
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <motion.div
           className="absolute -top-32 left-1/3 w-[700px] h-[500px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(229,9,20,0.18) 0%, transparent 65%)' }}
+          style={{ background: 'radial-gradient(ellipse, rgba(229,9,20,0.40) 0%, transparent 65%)' }}
           animate={{ scale: [1, 1.12, 1], opacity: [0.7, 1, 0.7] }}
           transition={{ duration: 7, repeat: Infinity, ease: 'easeInOut' }}
         />
         <motion.div
           className="absolute bottom-0 -right-32 w-[600px] h-[600px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(109,40,217,0.11) 0%, transparent 65%)' }}
+          style={{ background: 'radial-gradient(ellipse, rgba(109,40,217,0.28) 0%, transparent 65%)' }}
           animate={{ scale: [1.1, 1, 1.1], opacity: [0.4, 0.7, 0.4] }}
           transition={{ duration: 10, repeat: Infinity, ease: 'easeInOut', delay: 1 }}
         />
         <motion.div
           className="absolute top-1/3 -left-24 w-[400px] h-[400px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(255,107,53,0.08) 0%, transparent 65%)' }}
+          style={{ background: 'radial-gradient(ellipse, rgba(255,107,53,0.22) 0%, transparent 65%)' }}
           animate={{ scale: [1, 1.15, 1], opacity: [0.3, 0.6, 0.3] }}
           transition={{ duration: 9, repeat: Infinity, ease: 'easeInOut', delay: 3 }}
         />
@@ -201,7 +201,7 @@ export default function Home() {
             {/* Glow pool */}
             <div
               className="absolute bottom-12 left-1/2 -translate-x-1/2 w-72 h-6 pointer-events-none"
-              style={{ background: 'radial-gradient(ellipse, rgba(229,9,20,0.22) 0%, transparent 70%)', filter: 'blur(14px)' }}
+              style={{ background: 'radial-gradient(ellipse, rgba(229,9,20,0.45) 0%, transparent 70%)', filter: 'blur(14px)' }}
             />
 
             <motion.p


### PR DESCRIPTION
background-attachment:fixed is silently ignored on iOS Safari. Moved to a position:fixed div in root layout that renders on all pages. Bumped all gradient opacities significantly.