### PR TITLE
fix: stronger orange glow

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -35,6 +35,7 @@ export default function RootLayout({
             background: [
               'radial-gradient(ellipse at 15% 10%,  rgba(229,9,20,0.42)   0%, transparent 55%)',
               'radial-gradient(ellipse at 88% 88%,  rgba(109,40,217,0.30) 0%, transparent 55%)',
+              'radial-gradient(ellipse at 80% 10%,  rgba(255,107,53,0.28) 0%, transparent 50%)',
               'radial-gradient(ellipse at 50% 105%, rgba(229,9,20,0.18)   0%, transparent 45%)',
             ].join(', '),
           }}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
         />
         <motion.div
           className="absolute top-1/3 -left-24 w-[400px] h-[400px] rounded-full"
-          style={{ background: 'radial-gradient(ellipse, rgba(255,107,53,0.22) 0%, transparent 65%)' }}
+          style={{ background: 'radial-gradient(ellipse, rgba(255,107,53,0.50) 0%, transparent 65%)' }}
           animate={{ scale: [1, 1.15, 1], opacity: [0.3, 0.6, 0.3] }}
           transition={{ duration: 9, repeat: Infinity, ease: 'easeInOut', delay: 3 }}
         />


### PR DESCRIPTION
Home page orange blob: 22%→50%. Added orange (28%) to the global fixed background at top-right.