### PR TITLE
fix: host leaving lobby notifies players + confirms before leaving

### DIFF
--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
+import { getSocket } from '@/lib/socket';
 import { NAME_ADJECTIVES, NAME_NOUNS } from '@/lib/constants';
 import FilterPanel from '@/components/lobby/FilterPanel';
 import FilterPreview from '@/components/lobby/FilterPreview';
@@ -32,6 +33,7 @@ export default function CreatePage() {
   const [gameStarting, setGameStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const leavingRef = useRef(false);
 
   // If room already in store (e.g. back-navigation), skip to room step
   useEffect(() => {
@@ -40,6 +42,26 @@ export default function CreatePage() {
 
   useEffect(() => {
     if (step === 'name') setTimeout(() => inputRef.current?.select(), 50);
+  }, [step]);
+
+  // When host navigates away from the live lobby, notify the server so
+  // waiting players receive `roomClosed` immediately instead of waiting
+  // for the disconnect grace period.
+  // StrictMode guard: ref + setTimeout(0) — same pattern as lobby page.
+  useEffect(() => {
+    if (step !== 'room') return;
+    leavingRef.current = false;
+    return () => {
+      leavingRef.current = true;
+      setTimeout(() => {
+        if (!leavingRef.current) return;
+        // If Logo's handleLeave already ran, reset() clears the room → skip.
+        const { room: currentRoom } = useGameStore.getState();
+        if (currentRoom?.status === 'lobby') {
+          getSocket().emit('leaveRoom');
+        }
+      }, 0);
+    };
   }, [step]);
 
   const handleCreate = useCallback(() => {

--- a/apps/web/src/components/ui/Logo.tsx
+++ b/apps/web/src/components/ui/Logo.tsx
@@ -34,7 +34,7 @@ export default function Logo({ size = 'sm' }: LogoProps) {
   const longFiredRef = useRef(false);   // block the click that follows a long press
   const [pressing, setPressing] = useState(false); // subtle visual feedback
 
-  const isInGame = !!room && room.status !== 'lobby';
+  const isInGame = !!room; // confirm any time there's an active room (lobby or in-game)
 
   const clearTimer = () => {
     if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
@@ -108,7 +108,9 @@ export default function Logo({ size = 'sm' }: LogoProps) {
       {/* ── Leave-game confirmation modal ── */}
       <Modal isOpen={showConfirm} onClose={() => setShowConfirm(false)} title="Leave Game?">
         <p className="text-gray-400 mb-6">
-          Are you sure you want to leave? Your progress will be lost.
+          {room?.status === 'lobby'
+            ? 'Are you sure? Players waiting in the lobby will be disconnected.'
+            : 'Are you sure you want to leave? Your progress will be lost.'}
         </p>
         <div className="flex gap-3">
           <Button onClick={() => setShowConfirm(false)} variant="secondary" className="flex-1">


### PR DESCRIPTION
## Problem
Two bugs when host leaves before the game starts:
1. **No notification to players** — navigating away from `/create` step 2 did not emit `leaveRoom`, so waiting players were stuck until the 5s disconnect grace expired
2. **No confirmation prompt** — Logo's `isInGame` was `room.status !== 'lobby'`, so host could silently bail on waiting players

## Fix

### Logo.tsx
- Changed `isInGame` from `!!room && room.status !== 'lobby'` → `!!room`
- Any time there is an active room (lobby *or* in-game), clicking the Logo shows the confirm dialog
- Modal message is context-aware: *"Players waiting in the lobby will be disconnected"* vs *"Your progress will be lost"*

### create/page.tsx
- Imported `getSocket`
- Added `leavingRef` + `useEffect` cleanup (same StrictMode-safe `ref + setTimeout(0)` pattern as the lobby page)
- When host unmounts `/create` at step 2, emits `leaveRoom` → server immediately broadcasts `roomClosed` to all waiting players
- Guard: if Logo's `handleLeave` already ran, `reset()` cleared the room → cleanup checks store and skips (no double-emit)

## Behaviour After Fix
| Scenario | Before | After |
|---|---|---|
| Host clicks Logo at step 2 | Silently navigates home | "Are you sure?" dialog |
| Host confirms and leaves | `leaveRoom` from Logo | Same (cleanup skips via null-room guard) |
| Host presses browser back | Players stuck ~5s | Immediate `roomClosed` to all players |
