### PR TITLE
fix: symmetric delete bg gradient

### DIFF
--- a/apps/web/src/components/results/GameHistory.tsx
+++ b/apps/web/src/components/results/GameHistory.tsx
@@ -71,7 +71,7 @@ function DeletableHistoryItem({ entry, onDelete }: RowProps) {
         {/* Delete layer — dark crimson gradient, easy on the eyes */}
         <div
           className="absolute inset-0"
-          style={{ background: 'linear-gradient(135deg, #1c0a0a 0%, #7f1d1d 100%)' }}
+          style={{ background: 'linear-gradient(to right, #7f1d1d 0%, #2d0808 50%, #7f1d1d 100%)' }}
         >
           {/* Left icon — visible when dragging left */}
           <motion.div


### PR DESCRIPTION
Replace 135deg diagonal gradient with a symmetric horizontal one: crimson on both left and right edges, dark in the center. The card covers the center, so both swipe directions reveal the same crimson color.