### PR TITLE
feat: wildcard flow — host-only pick, full winner card, history save

### DIFF
--- a/apps/socket-server/src/handlers/gameHandler.ts
+++ b/apps/socket-server/src/handlers/gameHandler.ts
@@ -145,4 +145,18 @@ export function registerGameHandlers(io: Server, socket: Socket) {
       socket.emit('swipeUndone', undone);
     }
   });
+
+  // Host picks the wildcard winner (no-matches flow)
+  socket.on('wildcardPick', (tmdbId: number) => {
+    if (!roomManager.isCreator(socket.id)) return;
+    const room = roomManager.getRoomBySocket(socket.id);
+    if (!room || room.status !== 'finished') return;
+
+    const title = room.titlePool.find(t => t.tmdbId === tmdbId);
+    if (!title) return;
+
+    room.winner = title;
+    io.to(room.code).emit('wildcardResult', title);
+    console.log(`[wildcardPick] Room ${room.code} wildcard winner: ${title.title}`);
+  });
 }

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -112,7 +112,11 @@ export default function ResultsPage() {
 
         {/* No matches */}
         {noMatches && (
-          <WildcardPicker candidates={wildcardCandidates} />
+          <WildcardPicker
+            candidates={wildcardCandidates}
+            isCreator={isCreator}
+            onPick={(tmdbId) => socket.emit('wildcardPick' as any, tmdbId)}
+          />
         )}
 
         {/* Ranking phase */}

--- a/apps/web/src/components/results/WildcardPicker.tsx
+++ b/apps/web/src/components/results/WildcardPicker.tsx
@@ -1,26 +1,26 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import type { TitleCard } from '@/types/game';
-import Confetti from './Confetti';
 import { useSound } from '@/hooks/useSound';
 
 interface WildcardPickerProps {
   candidates: TitleCard[];
+  isCreator: boolean;
+  onPick: (tmdbId: number) => void;
 }
 
-export default function WildcardPicker({ candidates }: WildcardPickerProps) {
+export default function WildcardPicker({ candidates, isCreator, onPick }: WildcardPickerProps) {
   const [spinning, setSpinning] = useState(false);
-  const [winner, setWinner] = useState<TitleCard | null>(null);
+  const [picked, setPicked] = useState(false);
   const [displayIndex, setDisplayIndex] = useState(0);
   const intervalRef = useRef<NodeJS.Timeout>();
   const { playTick, playWildcard } = useSound();
 
   const handleSpin = useCallback(() => {
-    if (spinning || candidates.length === 0) return;
+    if (spinning || picked || candidates.length === 0) return;
     setSpinning(true);
-    setWinner(null);
 
     let speed = 80;
     let idx = 0;
@@ -33,10 +33,10 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
 
       if (speed > 400) {
         setSpinning(false);
+        setPicked(true);
         const selected = candidates[Math.floor(Math.random() * candidates.length)];
-        setWinner(selected);
-        // Small delay so last tick sound clears, then play win sound
         setTimeout(() => playWildcard(), 150);
+        onPick(selected.tmdbId);
         return;
       }
 
@@ -44,7 +44,7 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
     };
 
     tick();
-  }, [candidates, spinning, playTick, playWildcard]);
+  }, [candidates, spinning, picked, playTick, playWildcard, onPick]);
 
   if (candidates.length === 0) {
     return <p className="text-gray-400 text-center">No close matches found.</p>;
@@ -61,7 +61,7 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
           <motion.div
             key={c.tmdbId}
             className={`w-20 rounded-lg overflow-hidden border-2 transition-colors ${
-              spinning && displayIndex === i ? 'border-primary' : winner?.tmdbId === c.tmdbId ? 'border-accent-gold' : 'border-dark-border'
+              spinning && displayIndex === i ? 'border-primary' : 'border-dark-border'
             }`}
           >
             {c.posterPath && <img src={c.posterPath} alt={c.title} className="w-full aspect-[2/3] object-cover" />}
@@ -70,7 +70,8 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
         ))}
       </div>
 
-      {!winner && (
+      {/* Host: spin button */}
+      {isCreator && !picked && (
         <motion.button
           onClick={handleSpin}
           disabled={spinning}
@@ -81,22 +82,18 @@ export default function WildcardPicker({ candidates }: WildcardPickerProps) {
         </motion.button>
       )}
 
-      <AnimatePresence>
-        {winner && (
-          <motion.div
-            initial={{ scale: 0.5, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            className="mt-4"
-          >
-            <Confetti />
-            <p className="text-accent-gold font-bold text-lg mb-2">The wildcard chose:</p>
-            <div className="bg-dark-card rounded-xl overflow-hidden border border-accent-gold max-w-[200px] mx-auto">
-              {winner.posterPath && <img src={winner.posterPath} alt={winner.title} className="w-full aspect-[2/3] object-cover" />}
-              <p className="p-2 font-bold">{winner.title}</p>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/* Host: picking in progress */}
+      {isCreator && picked && (
+        <p className="text-accent-gold font-semibold animate-pulse">Revealing…</p>
+      )}
+
+      {/* Guest: waiting for host */}
+      {!isCreator && (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="w-6 h-6 border-2 border-accent-gold border-t-transparent rounded-full animate-spin" />
+          <p className="text-gray-400 text-sm">Waiting for host to pick…</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -87,6 +87,10 @@ export function useSocket() {
       store.setWildcardCandidates(candidates);
     });
 
+    socket.on('wildcardResult', (winner) => {
+      store.setWinner(winner);
+    });
+
     (socket as any).on('roomReset', (room: any) => {
       // Reset game-specific flags so the new game starts clean.
       // Don't call store.reset() — that would wipe playerId.
@@ -126,6 +130,7 @@ export function useSocket() {
       socket.off('gameStats');
       socket.off('roomClosed');
       (socket as any).off('wildcardCandidates');
+      socket.off('wildcardResult');
       (socket as any).off('roomReset');
       (socket as any).off('loadingProgress');
       (socket as any).off('gameRejoined');

--- a/apps/web/src/types/socket.ts
+++ b/apps/web/src/types/socket.ts
@@ -8,6 +8,7 @@ export interface ServerToClientEvents {
   gameStarted: (titlePool: TitleCard[]) => void;
   playerProgress: (playerId: string, progress: number) => void;
   allPlayersFinished: (matchedTitles: TitleCard[]) => void;
+  wildcardResult: (winner: TitleCard) => void;
   firstMatch: (title: TitleCard) => void;
   rankingsReady: (winner: TitleCard, rankings: Array<{ title: TitleCard; avgRank: number }>) => void;
   swipeReveal: (reveals: Array<{ title: TitleCard; playerDecisions: Array<{ playerName: string; decision: string }> }>) => void;
@@ -26,6 +27,7 @@ export interface ClientToServerEvents {
   startGame: () => void;
   submitSwipe: (tmdbId: number, decision: 'like' | 'pass' | 'superlike') => void;
   undoSwipe: () => void;
+  wildcardPick: (tmdbId: number) => void;
   submitRanking: (rankings: Array<{ tmdbId: number; rank: number }>) => void;
   playAgain: (payload?: { playerId?: string }) => void;
   endGame: (payload?: { playerId?: string }) => void;


### PR DESCRIPTION
Fixes three bugs in the no-matches wildcard flow:

### 1. Host-only picking
- `WildcardPicker` now takes `isCreator` prop
- Host sees the "Wildcard Pick!" spin button
- Guests see a spinner + *"Waiting for host to pick…"* until the host decides

### 2. Full winner card + history saved
- Old code stored the winner in local component state only — `ResultReveal` never rendered and history was never saved
- New flow: host spin → `wildcardPick` event → server finds title in `titlePool` → broadcasts `wildcardResult` to the room → `store.setWinner()` → `ResultReveal` renders for everyone + `saveGameToHistory` fires

### 3. Socket plumbing
- `wildcardPick` (C→S): host emits selected `tmdbId`
- `wildcardResult` (S→C): server broadcasts full `TitleCard` to all players in room
- `useSocket.ts`: listens for `wildcardResult` → `store.setWinner()`