### PR TITLE
fix: home page logo → real <Logo> component

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import CreateGameButton from '@/components/landing/CreateGameButton';
 import JoinGameForm from '@/components/landing/JoinGameForm';
 import GameHistoryButton from '@/components/landing/GameHistoryButton';
+import Logo from '@/components/ui/Logo';
 
 /** Decorative poster cards for the right panel (TMDB public CDN) */
 const POSTER_CARDS = [
@@ -72,13 +73,7 @@ export default function Home() {
           >
             {/* Logo */}
             <div className="text-center lg:text-left mb-8 lg:mb-10">
-              <h1
-                className="font-black tracking-tight leading-none"
-                style={{ fontSize: 'clamp(3rem, 10vw, 6rem)' }}
-              >
-                <span className="text-white">Show</span>
-                <span className="gradient-text">Match</span>
-              </h1>
+              <Logo fontSize="clamp(3rem, 10vw, 6rem)" />
               <p className="mt-3 text-xs text-white/55 tracking-[0.3em] uppercase font-semibold">
                 Swipe · Match · Watch
               </p>

--- a/apps/web/src/components/ui/Logo.tsx
+++ b/apps/web/src/components/ui/Logo.tsx
@@ -11,11 +11,13 @@ import Button from './Button';
 
 interface LogoProps {
   size?: 'sm' | 'lg';
+  /** Override font size (e.g. 'clamp(3rem,10vw,6rem)') */
+  fontSize?: string;
 }
 
 const LONG_PRESS_MS = 500;
 
-export default function Logo({ size = 'sm' }: LogoProps) {
+export default function Logo({ size = 'sm', fontSize }: LogoProps) {
   const textSize = size === 'lg' ? 'text-[3.5rem] md:text-[4rem]' : 'text-2xl';
   const router = useRouter();
   const { room, reset, playerId } = useGameStore();
@@ -96,7 +98,10 @@ export default function Logo({ size = 'sm' }: LogoProps) {
         animate={{ scale: pressing ? 0.92 : 1, opacity: 1 }}
         transition={{ type: 'spring', duration: pressing ? 0.15 : 0.5, stiffness: 400, damping: 22 }}
       >
-        <span className={`font-bold ${textSize} tracking-tight`}>
+        <span
+          className={`font-bold ${fontSize ? '' : textSize} tracking-tight`}
+          style={fontSize ? { fontSize } : undefined}
+        >
           <span className="text-white">Show</span>
           <span className="gradient-text">Match</span>
         </span>


### PR DESCRIPTION
Home page had a hardcoded `<h1>` instead of the Logo component, so it was not a link and had no long-press panel.\n\nReplaced with `<Logo fontSize='clamp(3rem,10vw,6rem)' />` — added an optional `fontSize` prop to Logo so the home page keeps its existing fluid sizing.