### PR TITLE
feat: tap room code to copy

### DIFF
--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion';
 import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
 import { getSocket } from '@/lib/socket';
+import CopyableCode from '@/components/ui/CopyableCode';
 import { NAME_ADJECTIVES, NAME_NOUNS } from '@/lib/constants';
 import FilterPanel from '@/components/lobby/FilterPanel';
 import FilterPreview from '@/components/lobby/FilterPreview';
@@ -261,7 +262,7 @@ export default function CreatePage() {
           animate={{ opacity: 1, y: 0 }}
         >
           <p className="text-sm text-gray-400 mb-2">Room Code</p>
-          <p className="text-4xl font-mono font-bold tracking-[0.3em] text-white">{room.code}</p>
+          <CopyableCode code={room.code} textSize="text-4xl" tracking="tracking-[0.3em]" />
           <div className="mt-3 flex justify-center">
             <ShareButton code={room.code} />
           </div>

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion';
 import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
 import { getSocket } from '@/lib/socket';
+import CopyableCode from '@/components/ui/CopyableCode';
 import FilterPanel from '@/components/lobby/FilterPanel';
 import FilterPreview from '@/components/lobby/FilterPreview';
 import PlayerList from '@/components/lobby/PlayerList';
@@ -93,11 +94,7 @@ export default function LobbyPage() {
           />
 
           <p className="text-xs text-gray-500 uppercase tracking-[0.2em] mb-2">Room Code</p>
-          <p
-            className="relative text-5xl font-mono font-black tracking-[0.4em] code-glow text-white"
-          >
-            {room.code}
-          </p>
+          <CopyableCode code={room.code} />
           <div className="mt-3 flex justify-center">
             <ShareButton code={room.code} />
           </div>

--- a/apps/web/src/components/ui/CopyableCode.tsx
+++ b/apps/web/src/components/ui/CopyableCode.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { safeCopy } from '@/lib/clipboard';
+
+interface CopyableCodeProps {
+  code: string;
+  /** Tailwind text-size class, e.g. "text-4xl" or "text-5xl" */
+  textSize?: string;
+  /** Extra tracking class, e.g. "tracking-[0.3em]" */
+  tracking?: string;
+  /** Extra className on the wrapper */
+  className?: string;
+}
+
+export default function CopyableCode({
+  code,
+  textSize = 'text-5xl',
+  tracking = 'tracking-[0.4em]',
+  className = '',
+}: CopyableCodeProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    await safeCopy(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  }, [code]);
+
+  return (
+    <div className={`relative inline-flex flex-col items-center gap-1 ${className}`}>
+      <motion.button
+        onClick={handleCopy}
+        className={`font-mono font-black ${textSize} ${tracking} code-glow text-white cursor-pointer select-none`}
+        whileTap={{ scale: 0.94 }}
+        title="Tap to copy"
+      >
+        {code}
+      </motion.button>
+
+      {/* "tap to copy" hint — fades out once copied */}
+      <AnimatePresence mode="wait">
+        {copied ? (
+          <motion.span
+            key="copied"
+            className="text-xs text-green-400 font-semibold"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+          >
+            ✓ Copied!
+          </motion.span>
+        ) : (
+          <motion.span
+            key="hint"
+            className="text-[10px] text-gray-600 tracking-wide"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            tap to copy
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}


### PR DESCRIPTION
New `CopyableCode` component used in both the host create page and the lobby. Tap the code → clipboard copy via `safeCopy` (works on plain HTTP/LAN) → brief '✓ Copied!' feedback. Subtle 'tap to copy' hint always visible.