### PR TITLE
fix: year slider bubbles overlap sticky Start button

### DIFF
--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -282,7 +282,7 @@ export default function CreatePage() {
         <PlayerList players={room.players} />
 
         {/* Start Button */}
-        <div className="sticky bottom-4 pb-safe flex flex-col gap-2">
+        <div className="sticky bottom-4 pb-safe flex flex-col gap-2 z-10">
           {error && (
             <p className="text-sm text-accent-red text-center bg-dark-card rounded-xl px-4 py-2 border border-red-900">
               {error}

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -118,7 +118,7 @@ export default function LobbyPage() {
 
         {/* Start / Waiting */}
         {isCreator ? (
-          <div className="sticky bottom-4">
+          <div className="sticky bottom-4 z-10">
             <Button
               size="lg"
               onClick={handleStartGame}


### PR DESCRIPTION
Slider bubbles are absolutely positioned and overflow their container. Sticky button had no z-index so bubbles rendered on top. Added z-10 to sticky wrapper in both lobby and create pages.