### PR TITLE
feat: wildcard spin visible to all players + history drag perf

### DIFF
--- a/apps/socket-server/src/handlers/gameHandler.ts
+++ b/apps/socket-server/src/handlers/gameHandler.ts
@@ -146,6 +146,14 @@ export function registerGameHandlers(io: Server, socket: Socket) {
     }
   });
 
+  // Host started the wildcard spin — broadcast to guests so they see the animation too
+  socket.on('wildcardSpinStart', () => {
+    if (!roomManager.isCreator(socket.id)) return;
+    const room = roomManager.getRoomBySocket(socket.id);
+    if (!room) return;
+    socket.to(room.code).emit('wildcardSpinStart');
+  });
+
   // Host picks the wildcard winner (no-matches flow)
   socket.on('wildcardPick', (tmdbId: number) => {
     if (!roomManager.isCreator(socket.id)) return;

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -20,7 +20,7 @@ export default function ResultsPage() {
   const code = (params.code as string).toUpperCase();
   const socket = useSocket();
   const {
-    room, matchedTitles, winner, fullRankings, wildcardCandidates,
+    room, matchedTitles, winner, fullRankings, wildcardCandidates, wildcardSpinning,
     isFirstMatch, playerId, swipeReveal, gameStats, gameOver, setWinner, reset,
   } = useGameStore();
   const [rankingSubmitted, setRankingSubmitted] = useState(false);
@@ -115,6 +115,8 @@ export default function ResultsPage() {
           <WildcardPicker
             candidates={wildcardCandidates}
             isCreator={isCreator}
+            wildcardSpinning={wildcardSpinning}
+            onSpinStart={() => socket.emit('wildcardSpinStart' as any)}
             onPick={(tmdbId) => socket.emit('wildcardPick' as any, tmdbId)}
           />
         )}

--- a/apps/web/src/components/results/GameHistory.tsx
+++ b/apps/web/src/components/results/GameHistory.tsx
@@ -96,7 +96,7 @@ function DeletableHistoryItem({ entry, onDelete }: RowProps) {
           drag="x"
           dragMomentum={false}
           onDragEnd={handleDragEnd}
-          style={{ x, touchAction: 'pan-y' }}
+          style={{ x, touchAction: 'pan-y', willChange: 'transform' }}
           className="relative bg-dark-surface rounded-xl p-3 border border-dark-border cursor-grab active:cursor-grabbing select-none"
         >
           <div className="flex items-center gap-3">
@@ -165,7 +165,7 @@ export default function GameHistory({ isOpen, onClose }: GameHistoryProps) {
       ) : (
         <div className="space-y-2 max-h-[60vh] overflow-y-auto">
           <p className="text-xs text-gray-600 text-center pb-1">Swipe left or right to delete</p>
-          <AnimatePresence mode="popLayout" initial={false}>
+          <AnimatePresence mode="sync" initial={false}>
             {history.map(entry => (
               <DeletableHistoryItem
                 key={entry.id}

--- a/apps/web/src/components/results/WildcardPicker.tsx
+++ b/apps/web/src/components/results/WildcardPicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import type { TitleCard } from '@/types/game';
 import { useSound } from '@/hooks/useSound';
@@ -8,18 +8,24 @@ import { useSound } from '@/hooks/useSound';
 interface WildcardPickerProps {
   candidates: TitleCard[];
   isCreator: boolean;
+  wildcardSpinning: boolean; // true when host has started the spin (guests use this)
+  onSpinStart: () => void;   // emits wildcardSpinStart socket event
   onPick: (tmdbId: number) => void;
 }
 
-export default function WildcardPicker({ candidates, isCreator, onPick }: WildcardPickerProps) {
+export default function WildcardPicker({
+  candidates, isCreator, wildcardSpinning, onSpinStart, onPick,
+}: WildcardPickerProps) {
   const [spinning, setSpinning] = useState(false);
   const [picked, setPicked] = useState(false);
   const [displayIndex, setDisplayIndex] = useState(0);
   const intervalRef = useRef<NodeJS.Timeout>();
   const { playTick, playWildcard } = useSound();
 
+  // Host spin: accelerating slowdown, then picks winner
   const handleSpin = useCallback(() => {
     if (spinning || picked || candidates.length === 0) return;
+    onSpinStart();
     setSpinning(true);
 
     let speed = 80;
@@ -44,24 +50,48 @@ export default function WildcardPicker({ candidates, isCreator, onPick }: Wildca
     };
 
     tick();
-  }, [candidates, spinning, picked, playTick, playWildcard, onPick]);
+  }, [candidates, spinning, picked, playTick, playWildcard, onSpinStart, onPick]);
+
+  // Guest spin: starts when host triggers, runs at constant speed until
+  // wildcardResult arrives and this component unmounts
+  useEffect(() => {
+    if (isCreator || !wildcardSpinning) return;
+
+    let idx = 0;
+    let alive = true;
+
+    const tick = () => {
+      if (!alive) return;
+      idx = (idx + 1) % candidates.length;
+      setDisplayIndex(idx);
+      playTick();
+      intervalRef.current = setTimeout(tick, 100);
+    };
+
+    tick();
+    return () => { alive = false; clearTimeout(intervalRef.current); };
+  }, [wildcardSpinning, isCreator, candidates, playTick]);
 
   if (candidates.length === 0) {
     return <p className="text-gray-400 text-center">No close matches found.</p>;
   }
+
+  const isSpinning = spinning || (!isCreator && wildcardSpinning);
 
   return (
     <div className="text-center space-y-4">
       <h2 className="text-xl font-bold">No one could agree! 🤷</h2>
       <p className="text-gray-400">But here&apos;s what came closest...</p>
 
-      {/* Candidates */}
+      {/* Candidates — spinning highlight tracks displayIndex */}
       <div className="flex justify-center gap-2 mb-4">
         {candidates.slice(0, 3).map((c, i) => (
           <motion.div
             key={c.tmdbId}
             className={`w-20 rounded-lg overflow-hidden border-2 transition-colors ${
-              spinning && displayIndex === i ? 'border-primary' : 'border-dark-border'
+              isSpinning && displayIndex % candidates.slice(0, 3).length === i
+                ? 'border-primary'
+                : 'border-dark-border'
             }`}
           >
             {c.posterPath && <img src={c.posterPath} alt={c.title} className="w-full aspect-[2/3] object-cover" />}
@@ -82,13 +112,18 @@ export default function WildcardPicker({ candidates, isCreator, onPick }: Wildca
         </motion.button>
       )}
 
-      {/* Host: picking in progress */}
+      {/* Host: revealing */}
       {isCreator && picked && (
         <p className="text-accent-gold font-semibold animate-pulse">Revealing…</p>
       )}
 
-      {/* Guest: waiting for host */}
-      {!isCreator && (
+      {/* Guest: spinning in progress */}
+      {!isCreator && wildcardSpinning && (
+        <p className="text-accent-gold text-sm animate-pulse">Picking the wildcard…</p>
+      )}
+
+      {/* Guest: waiting for host to start */}
+      {!isCreator && !wildcardSpinning && (
         <div className="flex flex-col items-center gap-3 py-2">
           <div className="w-6 h-6 border-2 border-accent-gold border-t-transparent rounded-full animate-spin" />
           <p className="text-gray-400 text-sm">Waiting for host to pick…</p>

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -87,7 +87,12 @@ export function useSocket() {
       store.setWildcardCandidates(candidates);
     });
 
+    socket.on('wildcardSpinStart', () => {
+      store.setWildcardSpinning(true);
+    });
+
     socket.on('wildcardResult', (winner) => {
+      store.setWildcardSpinning(false);
       store.setWinner(winner);
     });
 
@@ -130,6 +135,7 @@ export function useSocket() {
       socket.off('gameStats');
       socket.off('roomClosed');
       (socket as any).off('wildcardCandidates');
+      socket.off('wildcardSpinStart');
       socket.off('wildcardResult');
       (socket as any).off('roomReset');
       (socket as any).off('loadingProgress');

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -10,6 +10,7 @@ interface GameStore {
   currentCardIndex: number;
   matchedTitles: TitleCard[];
   wildcardCandidates: TitleCard[];
+  wildcardSpinning: boolean;
   winner: TitleCard | null;
   fullRankings: Array<{ title: TitleCard; avgRank: number }>;
   swipeReveal: Array<{ title: TitleCard; playerDecisions: Array<{ playerName: string; decision: string }> }>;
@@ -31,6 +32,7 @@ interface GameStore {
   updatePlayerProgress: (playerId: string, progress: number) => void;
   setMatchedTitles: (titles: TitleCard[]) => void;
   setWildcardCandidates: (titles: TitleCard[]) => void;
+  setWildcardSpinning: (spinning: boolean) => void;
   setWinner: (winner: TitleCard) => void;
   setFullRankings: (rankings: Array<{ title: TitleCard; avgRank: number }>) => void;
   setSwipeReveal: (reveal: Array<{ title: TitleCard; playerDecisions: Array<{ playerName: string; decision: string }> }>) => void;
@@ -48,6 +50,7 @@ const initialState = {
   currentCardIndex: 0,
   matchedTitles: [] as TitleCard[],
   wildcardCandidates: [] as TitleCard[],
+  wildcardSpinning: false,
   winner: null as TitleCard | null,
   fullRankings: [] as Array<{ title: TitleCard; avgRank: number }>,
   swipeReveal: [] as Array<{ title: TitleCard; playerDecisions: Array<{ playerName: string; decision: string }> }>,
@@ -139,6 +142,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   setMatchedTitles: (titles) => set({ matchedTitles: titles }),
   setWildcardCandidates: (titles) => set({ wildcardCandidates: titles }),
+  setWildcardSpinning: (spinning) => set({ wildcardSpinning: spinning }),
   setWinner: (winner) => set({ winner }),
   setFullRankings: (rankings) => set({ fullRankings: rankings }),
   setSwipeReveal: (reveal) => set({ swipeReveal: reveal }),

--- a/apps/web/src/types/socket.ts
+++ b/apps/web/src/types/socket.ts
@@ -8,6 +8,7 @@ export interface ServerToClientEvents {
   gameStarted: (titlePool: TitleCard[]) => void;
   playerProgress: (playerId: string, progress: number) => void;
   allPlayersFinished: (matchedTitles: TitleCard[]) => void;
+  wildcardSpinStart: () => void;
   wildcardResult: (winner: TitleCard) => void;
   firstMatch: (title: TitleCard) => void;
   rankingsReady: (winner: TitleCard, rankings: Array<{ title: TitleCard; avgRank: number }>) => void;
@@ -27,6 +28,7 @@ export interface ClientToServerEvents {
   startGame: () => void;
   submitSwipe: (tmdbId: number, decision: 'like' | 'pass' | 'superlike') => void;
   undoSwipe: () => void;
+  wildcardSpinStart: () => void;
   wildcardPick: (tmdbId: number) => void;
   submitRanking: (rankings: Array<{ tmdbId: number; rank: number }>) => void;
   playAgain: (payload?: { playerId?: string }) => void;


### PR DESCRIPTION
**Wildcard animation for guests:**
Host clicks "Wildcard Pick!" → emits `wildcardSpinStart` → server relays to non-host players → guests run their own local spin animation cycling through candidates. When `wildcardResult` arrives, everyone transitions to `ResultReveal`.

**History drag performance:**
- `willChange: transform` on the draggable card div — promotes it to its own GPU compositing layer, preventing repaints of sibling elements during drag.