### PR TITLE
copy: remove em dashes from UI text

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import './globals.css';
 import PageTransitionWrapper from '@/components/ui/PageTransitionWrapper';
 
 export const metadata: Metadata = {
-  title: 'ShowMatch — Swipe. Match. Watch.',
+  title: 'ShowMatch · Swipe. Match. Watch.',
   description: 'Find something everyone wants to watch. Together.',
 };
 

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -127,7 +127,7 @@ export default function LobbyPage() {
             >
               {connectedCount < 2
                 ? `Waiting for players… (${connectedCount}/2)`
-                : `Start Game — ${connectedCount} players`
+                : `Start Game · ${connectedCount} players`
               }
             </Button>
           </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -18,7 +18,7 @@ const POSTER_CARDS = [
 const STEPS = [
   { emoji: '🎬', label: 'Pick the vibe',     desc: "Set the genre, era, and whether you're feeling movies or shows." },
   { emoji: '👆', label: 'Swipe together',   desc: 'Everyone in the room votes on the same titles in real time.' },
-  { emoji: '🎉', label: 'Watch together',  desc: "Mutual likes win — the crowd's pick is revealed live." },
+  { emoji: '🎉', label: 'Watch together',  desc: "Mutual likes win. The crowd's pick is revealed live." },
 ];
 
 export default function Home() {

--- a/apps/web/src/components/game/StreamingLogos.tsx
+++ b/apps/web/src/components/game/StreamingLogos.tsx
@@ -34,7 +34,7 @@ export default function StreamingLogos({ providers, searchTitle }: StreamingLogo
             href={jwUrl}
             target="_blank"
             rel="noopener noreferrer"
-            title={`Watch on ${p.name} — JustWatch`}
+            title={`Watch on ${p.name} via JustWatch`}
             onClick={e => e.stopPropagation()}
             className="opacity-90 hover:opacity-100 hover:scale-110 transition-all"
           >

--- a/apps/web/src/components/lobby/FilterPreview.tsx
+++ b/apps/web/src/components/lobby/FilterPreview.tsx
@@ -52,7 +52,7 @@ export default function FilterPreview({ settings }: FilterPreviewProps) {
       ) : count === null ? (
         <span className="text-sm text-gray-500">--</span>
       ) : count === 0 ? (
-        <span className="text-sm text-accent-red">No titles match — try broadening your filters</span>
+        <span className="text-sm text-accent-red">No titles match. Try broadening your filters.</span>
       ) : (
         <span className="text-sm">
           <span className="font-bold text-primary">{count.toLocaleString()}</span>


### PR DESCRIPTION
Replace all user-visible em dashes (—) with periods, middle dots, or 'via'. Code comments left unchanged.