### PR TITLE
fix: remove header border line

### DIFF
--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -250,7 +250,7 @@ export default function CreatePage() {
 
   return (
     <main className="min-h-screen">
-      <header className="flex items-center justify-between p-4 border-b border-dark-border">
+      <header className="flex items-center justify-between p-4">
         <Logo size="sm" />
       </header>
 

--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -132,7 +132,7 @@ export default function GamePage() {
     <main className="flex flex-col overflow-hidden" style={{ height: gameHeight, touchAction: 'pan-y' }}>
       <TutorialOverlay onDismiss={() => setShowTutorial(false)} forceShow={showTutorial} />
       {/* Header */}
-      <header className="flex items-center justify-between px-4 py-2.5 border-b border-dark-border bg-dark/90 backdrop-blur-md">
+      <header className="flex items-center justify-between px-4 py-2.5 bg-dark/90 backdrop-blur-md">
         <Logo size="sm" />
         <TutorialReplayButton onClick={() => {
           localStorage.removeItem('showmatch-tutorial-seen');

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -75,7 +75,7 @@ export default function LobbyPage() {
   return (
     <main className="min-h-screen">
       {/* Frosted glass header */}
-      <header className="flex items-center justify-between px-4 py-3 border-b border-dark-border bg-dark/90 backdrop-blur-md sticky top-0 z-20">
+      <header className="flex items-center justify-between px-4 py-3 bg-dark/90 backdrop-blur-md sticky top-0 z-20">
         <Logo size="sm" />
       </header>
 

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -97,7 +97,7 @@ export default function ResultsPage() {
 
   return (
     <main className="min-h-screen pb-36">
-      <header className="flex items-center px-4 py-3 border-b border-dark-border bg-dark/90 backdrop-blur-md sticky top-0 z-20">
+      <header className="flex items-center px-4 py-3 bg-dark/90 backdrop-blur-md sticky top-0 z-20">
         <Logo size="sm" />
       </header>
 


### PR DESCRIPTION
Remove border-b border-dark-border from lobby, create, game, and results page headers. The backdrop-blur on the sticky header provides enough visual separation.