### PR TITLE
fix: header background opacity 90% → 60%

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -132,7 +132,7 @@ export default function GamePage() {
     <main className="flex flex-col overflow-hidden" style={{ height: gameHeight, touchAction: 'pan-y' }}>
       <TutorialOverlay onDismiss={() => setShowTutorial(false)} forceShow={showTutorial} />
       {/* Header */}
-      <header className="flex items-center justify-between px-4 py-2.5 bg-dark/90 backdrop-blur-md">
+      <header className="flex items-center justify-between px-4 py-2.5 bg-dark/60 backdrop-blur-md">
         <Logo size="sm" />
         <TutorialReplayButton onClick={() => {
           localStorage.removeItem('showmatch-tutorial-seen');

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -75,7 +75,7 @@ export default function LobbyPage() {
   return (
     <main className="min-h-screen">
       {/* Frosted glass header */}
-      <header className="flex items-center justify-between px-4 py-3 bg-dark/90 backdrop-blur-md sticky top-0 z-20">
+      <header className="flex items-center justify-between px-4 py-3 bg-dark/60 backdrop-blur-md sticky top-0 z-20">
         <Logo size="sm" />
       </header>
 

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -97,7 +97,7 @@ export default function ResultsPage() {
 
   return (
     <main className="min-h-screen pb-36">
-      <header className="flex items-center px-4 py-3 bg-dark/90 backdrop-blur-md sticky top-0 z-20">
+      <header className="flex items-center px-4 py-3 bg-dark/60 backdrop-blur-md sticky top-0 z-20">
         <Logo size="sm" />
       </header>
 
@@ -175,7 +175,7 @@ export default function ResultsPage() {
 
       {/* Sticky footer — always visible once game is over */}
       {(winner || noMatches) && (
-        <div className="fixed bottom-0 left-0 right-0 z-10 bg-dark/90 backdrop-blur-md border-t border-dark-border shadow-[0_-4px_32px_rgba(0,0,0,0.5)]">
+        <div className="fixed bottom-0 left-0 right-0 z-10 bg-dark/60 backdrop-blur-md border-t border-dark-border shadow-[0_-4px_32px_rgba(0,0,0,0.5)]">
           <div className="max-w-lg mx-auto p-3 flex gap-2">
             <button
               onClick={handleShare}


### PR DESCRIPTION
The global fixed radial gradient (layout.tsx) was blocked by bg-dark/90 on all sticky headers, making them look pure black. Reduced to bg-dark/60 so the atmospheric gradient shows through while backdrop-blur still handles content scrolling underneath.