### PR TITLE
feat: Tailscale / any-network access

### DIFF
--- a/apps/socket-server/src/index.ts
+++ b/apps/socket-server/src/index.ts
@@ -10,12 +10,13 @@ import { registerRankingHandlers } from './handlers/rankingHandler';
 dotenv.config();
 
 const app = express();
-app.use(cors({ origin: 'http://localhost:3000' }));
+// Allow any origin — this app runs on a private LAN / Tailscale VPN
+app.use(cors({ origin: true }));
 
 const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: {
-    origin: 'http://localhost:3000',
+    origin: true,
     methods: ['GET', 'POST'],
   },
 });

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -9,7 +9,13 @@ let socket: TypedSocket | null = null;
 
 export function getSocket(): TypedSocket {
   if (!socket) {
-    const url = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+    // Derive the socket URL from the current browser hostname so the app works
+    // over any network (LAN, Tailscale, localhost) without reconfiguration.
+    // NEXT_PUBLIC_SOCKET_URL overrides this if set explicitly.
+    const url = process.env.NEXT_PUBLIC_SOCKET_URL
+      ?? (typeof window !== 'undefined'
+        ? `http://${window.location.hostname}:3001`
+        : 'http://localhost:3001');
     socket = io(url, {
       autoConnect: false,
       transports: ['websocket', 'polling'],


### PR DESCRIPTION
**Problem:** App only worked on the local LAN because the socket URL was hardcoded to `192.168.1.236:3001` and CORS only allowed `localhost:3000`.

**Fix:**
- `socket.ts`: derive socket URL from `window.location.hostname` at runtime — if you access `http://100.x.x.x:3000` over Tailscale, the socket automatically connects to `100.x.x.x:3001`
- Removed `NEXT_PUBLIC_SOCKET_URL` from `.env.local`
- Socket server CORS: `origin: true` (allow all) — safe for a private LAN/VPN app