### PR TITLE
fix: align join button height to match code input

### DIFF
--- a/apps/web/src/components/landing/JoinGameForm.tsx
+++ b/apps/web/src/components/landing/JoinGameForm.tsx
@@ -46,7 +46,7 @@ export default function JoinGameForm() {
         />
 
         {/* Join button — springs to life when 5 chars entered */}
-        <div className="relative shrink-0">
+        <div className="relative shrink-0 self-stretch flex flex-col">
           {/* Pulsing glow ring — only when ready */}
           <AnimatePresence>
             {ready && !checking && (
@@ -66,7 +66,7 @@ export default function JoinGameForm() {
           <motion.button
             onClick={handleJoin}
             disabled={!ready || checking}
-            className="relative px-6 py-4 rounded-xl font-black text-sm text-white overflow-hidden"
+            className="relative flex-1 px-6 rounded-xl font-black text-sm text-white overflow-hidden flex items-center justify-center"
             animate={
               ready
                 ? { scale: 1, opacity: 1 }


### PR DESCRIPTION
The button used `py-4 text-sm` while the input used `py-4 text-xl` — different font sizes with same padding produced different heights.

Fix: wrapper div gets `self-stretch flex-col` so it fills the input's height via flexbox. Button gets `flex-1` instead of `py-4` so it fills the wrapper. Heights are now always identical.