### PR TITLE
feat: persist session across page refresh

### DIFF
--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -9,6 +9,7 @@ import { getSocket } from '@/lib/socket';
 import CopyableCode from '@/components/ui/CopyableCode';
 import { NAME_ADJECTIVES, NAME_NOUNS } from '@/lib/constants';
 import FilterPanel from '@/components/lobby/FilterPanel';
+import { saveSession, clearSession } from '@/lib/session';
 import FilterPreview from '@/components/lobby/FilterPreview';
 import PlayerList from '@/components/lobby/PlayerList';
 import ShareButton from '@/components/lobby/ShareButton';
@@ -36,10 +37,10 @@ export default function CreatePage() {
   const inputRef = useRef<HTMLInputElement>(null);
   const leavingRef = useRef(false);
 
-  // If room already in store (e.g. back-navigation), skip to room step
+  // If room already in store (back-navigation or rejoin after refresh), skip to room step
   useEffect(() => {
     if (room) setStep('room');
-  }, []);
+  }, [room]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (step === 'name') setTimeout(() => inputRef.current?.select(), 50);
@@ -59,6 +60,7 @@ export default function CreatePage() {
         // If Logo's handleLeave already ran, reset() clears the room → skip.
         const { room: currentRoom } = useGameStore.getState();
         if (currentRoom?.status === 'lobby') {
+          clearSession();
           getSocket().emit('leaveRoom');
         }
       }, 0);
@@ -78,6 +80,7 @@ export default function CreatePage() {
       }
       setRoom(response.room);
       setPlayerId(socket.id || '');
+      saveSession({ code: response.room.code, displayName: trimmed });
       setStep('room');
       setCreating(false);
     });

--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -38,7 +38,7 @@ export default function GamePage() {
   const {
     room, titlePool, currentCardIndex, mySwipes,
     matchedTitles, winner, isFirstMatch, gameOver,
-    recordSwipe, undoLastSwipe, playerId,
+    recordSwipe, undoLastSwipe, playerId, reconnecting,
   } = useGameStore();
   const { playLike, playPass, playSuperLike } = useSound();
 
@@ -55,10 +55,10 @@ export default function GamePage() {
   const [dragDirection, setDragDirection] = useState<'like' | 'pass' | 'superlike' | null>(null);
 
   useEffect(() => {
-    if (!room || !titlePool.length) {
+    if (!reconnecting && !room) {
       router.push('/');
     }
-  }, [room, titlePool, router]);
+  }, [reconnecting, room, router]);
 
   // Redirect to results
   useEffect(() => {
@@ -122,6 +122,14 @@ export default function GamePage() {
     return () => window.removeEventListener('keydown', handler);
   }, [room, titlePool, currentCardIndex, pendingDecision, playerId]);
 
+  if (reconnecting) return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center space-y-3">
+        <div className="text-3xl animate-pulse">🎬</div>
+        <p className="text-gray-400 text-sm tracking-wide">Reconnecting...</p>
+      </div>
+    </div>
+  );
   if (!room || !titlePool.length) return null;
 
   const isFinished = currentCardIndex >= titlePool.length;

--- a/apps/web/src/app/join/[code]/page.tsx
+++ b/apps/web/src/app/join/[code]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
+import { saveSession } from '@/lib/session';
 import { NAME_ADJECTIVES, NAME_NOUNS } from '@/lib/constants';
 import Logo from '@/components/ui/Logo';
 
@@ -58,6 +59,7 @@ export default function JoinPage() {
         }
         setRoom(response.room);
         setPlayerId(socket.id || '');
+        saveSession({ code, displayName: name.trim() });
         router.push(`/lobby/${code}`);
       });
     };

--- a/apps/web/src/app/lobby/[code]/page.tsx
+++ b/apps/web/src/app/lobby/[code]/page.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion';
 import { useSocket } from '@/hooks/useSocket';
 import { useGameStore } from '@/stores/gameStore';
 import { getSocket } from '@/lib/socket';
+import { clearSession } from '@/lib/session';
 import CopyableCode from '@/components/ui/CopyableCode';
 import FilterPanel from '@/components/lobby/FilterPanel';
 import FilterPreview from '@/components/lobby/FilterPreview';
@@ -20,13 +21,13 @@ export default function LobbyPage() {
   const params = useParams();
   const code = (params.code as string).toUpperCase();
   const socket = useSocket();
-  const { room, playerId, updateSettings } = useGameStore();
+  const { room, playerId, updateSettings, reconnecting } = useGameStore();
 
   useEffect(() => {
-    if (!room) {
+    if (!reconnecting && !room) {
       router.push(`/join/${code}`);
     }
-  }, [room, code, router]);
+  }, [reconnecting, room, code, router]);
 
   useEffect(() => {
     if (room?.status === 'swiping') {
@@ -51,12 +52,21 @@ export default function LobbyPage() {
         if (!leavingRef.current) return; // StrictMode remount already reset this
         const { room: currentRoom } = useGameStore.getState();
         if (currentRoom?.status === 'lobby') {
+          clearSession();
           getSocket().emit('leaveRoom');
         }
       }, 0);
     };
   }, []);
 
+  if (reconnecting) return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center space-y-3">
+        <div className="text-3xl animate-pulse">🎬</div>
+        <p className="text-gray-400 text-sm tracking-wide">Reconnecting...</p>
+      </div>
+    </div>
+  );
   if (!room) return null;
 
   const isCreator = room.players.find(p => p.id === playerId)?.isCreator ?? false;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import CreateGameButton from '@/components/landing/CreateGameButton';
+import { clearSession } from '@/lib/session';
 import JoinGameForm from '@/components/landing/JoinGameForm';
 import GameHistoryButton from '@/components/landing/GameHistoryButton';
 import Logo from '@/components/ui/Logo';
@@ -25,6 +26,8 @@ export default function Home() {
   const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
+    // User reached home intentionally — clear any stale reconnect session
+    clearSession();
     const msg = sessionStorage.getItem('showmatch-toast');
     if (msg) {
       setToast(msg);

--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -11,6 +11,7 @@ import SwipeReveal from '@/components/results/SwipeReveal';
 import GameStats from '@/components/results/GameStats';
 import Logo from '@/components/ui/Logo';
 import { saveGameToHistory } from '@/lib/history';
+import { clearSession } from '@/lib/session';
 import { safeCopy } from '@/lib/clipboard';
 import { shareText } from '@/lib/share';
 
@@ -21,7 +22,7 @@ export default function ResultsPage() {
   const socket = useSocket();
   const {
     room, matchedTitles, winner, fullRankings, wildcardCandidates, wildcardSpinning,
-    isFirstMatch, playerId, swipeReveal, gameStats, gameOver, setWinner, reset,
+    isFirstMatch, playerId, swipeReveal, gameStats, gameOver, setWinner, reset, reconnecting,
   } = useGameStore();
   const [rankingSubmitted, setRankingSubmitted] = useState(false);
   const [historySaved, setHistorySaved] = useState(false);
@@ -49,10 +50,10 @@ export default function ResultsPage() {
   }, [winner, room, historySaved, code, gameStats]);
 
   useEffect(() => {
-    if (!room) {
+    if (!reconnecting && !room) {
       router.push('/');
     }
-  }, [room, router]);
+  }, [reconnecting, room, router]);
 
   useEffect(() => {
     if (room?.status === 'lobby') {
@@ -71,8 +72,7 @@ export default function ResultsPage() {
 
   const handleEndGame = useCallback(() => {
     (socket as any).emit('endGame', { playerId });
-    // Host navigates themselves — server will notify guests via socket.to() (not io.to())
-    // so the host won't receive the roomClosed toast.
+    clearSession();
     reset();
     router.push('/');
   }, [socket, playerId, reset, router]);
@@ -87,6 +87,14 @@ export default function ResultsPage() {
     }
   }, [winner]);
 
+  if (reconnecting) return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center space-y-3">
+        <div className="text-3xl animate-pulse">🎬</div>
+        <p className="text-gray-400 text-sm tracking-wide">Reconnecting...</p>
+      </div>
+    </div>
+  );
   if (!room) return null;
 
   const isCreator = room.players.find(p => p.id === playerId)?.isCreator ?? false;

--- a/apps/web/src/components/ui/Logo.tsx
+++ b/apps/web/src/components/ui/Logo.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { useGameStore } from '@/stores/gameStore';
 import { getSocket } from '@/lib/socket';
+import { clearSession } from '@/lib/session';
 import Modal from './Modal';
 import Button from './Button';
 
@@ -76,6 +77,7 @@ export default function Logo({ size = 'sm', fontSize }: LogoProps) {
     try {
       getSocket().emit('leaveRoom', { playerId: playerId ?? undefined });
     } catch {}
+    clearSession();
     reset();
     setShowConfirm(false);
     router.push('/');

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -4,27 +4,41 @@ import { useEffect, useRef } from 'react';
 import { connectSocket, getSocket } from '@/lib/socket';
 import { useGameStore } from '@/stores/gameStore';
 import { playSound } from '@/lib/sounds';
+import { loadSession, clearSession } from '@/lib/session';
 import type { Socket } from 'socket.io-client';
 
 export function useSocket() {
   const socketRef = useRef<Socket | null>(null);
   const store = useGameStore();
-  // Track whether this socket has connected at least once so we can
-  // distinguish a reconnect (true) from the initial connection (false).
   const everConnectedRef = useRef(false);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const socket = connectSocket();
     socketRef.current = socket;
 
-    // On every (re)connect: if we were already connected before, try to
-    // re-attach to the room.  Handles both brief disconnects and full
-    // server restarts (server responds with roomClosed if room is gone).
+    // On every (re)connect: try to re-attach to an active room.
+    // • First connect + session in sessionStorage → page refresh case
+    // • Re-connect (socket dropped) + room in Zustand → brief disconnect case
     socket.on('connect', () => {
       if (!everConnectedRef.current) {
         everConnectedRef.current = true;
-        return; // initial connect — nothing to rejoin
+        // Page-refresh case: Zustand is empty but sessionStorage may have a session
+        const session = loadSession();
+        if (session) {
+          useGameStore.getState().setReconnecting(true);
+          socket.emit('rejoinGame', { code: session.code, displayName: session.displayName });
+          // Safety net: if server never responds, stop blocking after 5s
+          reconnectTimerRef.current = setTimeout(() => {
+            if (useGameStore.getState().reconnecting) {
+              clearSession();
+              useGameStore.getState().setReconnecting(false);
+            }
+          }, 5000);
+        }
+        return;
       }
+      // Brief-disconnect case: Zustand still has the room
       const { room, playerId } = useGameStore.getState();
       if (!room) return;
       const me = room.players.find(p => p.id === playerId);
@@ -103,18 +117,51 @@ export function useSocket() {
       store.setRoom(room);
     });
 
-    (socket as any).on('gameRejoined', (room: any) => {
-      // Successfully re-attached to existing room after reconnect.
-      // Update room state; keep client-side progress (currentCardIndex) intact.
+    (socket as any).on('gameRejoined', (room: any, titlePool: any[]) => {
+      if (reconnectTimerRef.current) { clearTimeout(reconnectTimerRef.current); reconnectTimerRef.current = null; }
+      // Successfully re-attached. Restore as much state as possible.
+      const session = loadSession();
+      const me = room.players.find((p: any) =>
+        p.id === socket.id ||
+        (session && p.displayName === session.displayName)
+      );
+
       store.setRoom(room);
+      if (me) store.setPlayerId(me.id);
+
+      if (room.status === 'swiping' && titlePool?.length) {
+        // Active game: restore the title pool and resume from where this player left off
+        store.setTitlePool(titlePool);
+        store.setCurrentCardIndex(me?.progress ?? 0);
+      } else if ((room.status === 'ranking' || room.status === 'finished') && titlePool?.length) {
+        // Results screen: restore pool + end-state flags
+        store.setTitlePool(titlePool);
+        store.setGameOver(true);
+        if (room.matchedTitles?.length) store.setMatchedTitles(room.matchedTitles);
+        if (room.winner) store.setWinner(room.winner);
+      }
+
+      store.setReconnecting(false);
+
+      // Navigate to the correct page based on room status
+      if (typeof window === 'undefined') return;
+      const path = window.location.pathname;
+      if (room.status === 'swiping' && !path.includes('/game/')) {
+        window.location.href = `/game/${room.code}`;
+      } else if ((room.status === 'ranking' || room.status === 'finished') && !path.includes('/results/')) {
+        window.location.href = `/results/${room.code}`;
+      } else if (room.status === 'lobby' && me?.isCreator && !path.includes('/create')) {
+        window.location.href = '/create';
+      } else if (room.status === 'lobby' && !me?.isCreator && !path.includes(`/lobby/${room.code}`)) {
+        window.location.href = `/lobby/${room.code}`;
+      }
+      // If already on the right page, do nothing — store update is enough
     });
 
     socket.on('roomClosed', (reason) => {
-      // Don't call store.reset() here — it nullifies `room` which triggers the
-      // game page's guard effect to do a SPA navigation that races with our
-      // window.location.href below and can eat the toast from sessionStorage.
-      // A full-page reload (window.location.href) already wipes all in-memory
-      // state, so the reset is redundant anyway.
+      if (reconnectTimerRef.current) { clearTimeout(reconnectTimerRef.current); reconnectTimerRef.current = null; }
+      clearSession(); // room is gone — don't attempt rejoin on next refresh
+      store.setReconnecting(false);
       if (typeof window !== 'undefined') {
         sessionStorage.setItem('showmatch-toast', reason);
         window.location.href = '/';

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -1,0 +1,29 @@
+/**
+ * Lightweight session persistence via sessionStorage.
+ * Survives page refresh within the same tab; cleared when the tab closes.
+ * Used to attempt socket rejoin after a refresh mid-game.
+ */
+
+const KEY = 'showmatch-session';
+
+export interface SessionData {
+  code: string;
+  displayName: string;
+}
+
+export function saveSession(data: SessionData): void {
+  try { sessionStorage.setItem(KEY, JSON.stringify(data)); } catch {}
+}
+
+export function loadSession(): SessionData | null {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as SessionData) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSession(): void {
+  try { sessionStorage.removeItem(KEY); } catch {}
+}

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -19,6 +19,8 @@ interface GameStore {
   isFirstMatch: boolean;
   loadingProgress: { stage: string; progress: number; total?: number } | null;
   gameOver: boolean;
+  /** True while attempting socket rejoin after a page refresh. Prevents premature redirects. */
+  reconnecting: boolean;
 
   setRoom: (room: Room | null) => void;
   setPlayerId: (id: string) => void;
@@ -40,6 +42,9 @@ interface GameStore {
   setIsFirstMatch: (val: boolean) => void;
   setLoadingProgress: (data: { stage: string; progress: number; total?: number } | null) => void;
   setGameOver: (val: boolean) => void;
+  setReconnecting: (val: boolean) => void;
+  setCurrentCardIndex: (idx: number) => void;
+  setTitlePool: (pool: TitleCard[]) => void;
   reset: () => void;
 }
 
@@ -59,6 +64,7 @@ const initialState = {
   isFirstMatch: false,
   loadingProgress: null as { stage: string; progress: number; total?: number } | null,
   gameOver: false,
+  reconnecting: false,
 };
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -150,6 +156,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
   setIsFirstMatch: (val) => set({ isFirstMatch: val }),
   setLoadingProgress: (data) => set({ loadingProgress: data }),
   setGameOver: (val) => set({ gameOver: val }),
+  setReconnecting: (val) => set({ reconnecting: val }),
+  setCurrentCardIndex: (idx) => set({ currentCardIndex: idx }),
+  setTitlePool: (pool) => set({ titlePool: pool }),
 
   reset: () => set(initialState),
 }));


### PR DESCRIPTION
Fixes the bug where refreshing mid-game kicked you back to the home screen.

**How it works:**
- `sessionStorage` stores `{code, displayName}` after joining/creating a room
- On socket connect (including after refresh), if a session exists the client immediately emits `rejoinGame`
- The server's existing `rejoinGame` handler re-attaches the socket, migrates swipes/rankings, and returns the full room + titlePool
- Client restores: room state, playerId, currentCardIndex (swipe position), gameOver/matchedTitles/winner for results screens
- A `reconnecting` flag blocks all redirect guards during the ~200ms rejoin window; pages show a spinner instead
- 5s safety timeout prevents being stuck if the server doesn't respond
- Session is cleared on: intentional leave (Logo), endGame, roomClosed (kicked), and home page mount