### PR TITLE
fix: join button height always matches code input

### DIFF
--- a/apps/web/src/components/landing/JoinGameForm.tsx
+++ b/apps/web/src/components/landing/JoinGameForm.tsx
@@ -46,7 +46,7 @@ export default function JoinGameForm() {
         />
 
         {/* Join button — springs to life when 5 chars entered */}
-        <div className="relative shrink-0 self-stretch flex flex-col">
+        <div className="relative shrink-0 self-stretch">
           {/* Pulsing glow ring — only when ready */}
           <AnimatePresence>
             {ready && !checking && (
@@ -66,12 +66,8 @@ export default function JoinGameForm() {
           <motion.button
             onClick={handleJoin}
             disabled={!ready || checking}
-            className="relative flex-1 px-6 rounded-xl font-black text-sm text-white overflow-hidden flex items-center justify-center"
-            animate={
-              ready
-                ? { scale: 1, opacity: 1 }
-                : { scale: 0.96, opacity: 0.35 }
-            }
+            className="relative h-full px-6 rounded-xl font-black text-sm text-white overflow-hidden flex items-center justify-center"
+            animate={{ opacity: ready ? 1 : 0.35 }}
             initial={false}
             transition={{ type: 'spring', stiffness: 500, damping: 18 }}
             whileTap={ready ? { scale: 0.88 } : {}}


### PR DESCRIPTION
Two issues caused visual misalignment:
1. `scale: 0.96` in the Framer Motion animate prop visually shrunk the button when no code was entered
2. `flex-1` inside `flex-col` was fragile

Fix: drop scale animation entirely (opacity only for not-ready state), use `h-full` on the button directly.