### PR TITLE
feat: add credit link on all screens

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -180,3 +180,22 @@ input[type="range"].range-thumb::-moz-range-track {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: #1e1d38; border-radius: 2px; }
 ::-webkit-scrollbar-thumb:hover { background: #e50914; }
+
+/* ─── Credit link ──────────────────────────────────────────── */
+.credit-link {
+  position: fixed;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  z-index: 9999;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.25);
+  text-decoration: none;
+  pointer-events: auto;
+  transition: color 0.2s;
+}
+.credit-link:hover {
+  color: rgba(255, 255, 255, 0.7);
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import PageTransitionWrapper from '@/components/ui/PageTransitionWrapper';
+import CreditLink from '@/components/ui/CreditLink';
 
 export const metadata: Metadata = {
   title: 'ShowMatch · Swipe. Match. Watch.',
@@ -43,6 +44,9 @@ export default function RootLayout({
         <div style={{ position: 'relative', zIndex: 1 }}>
           <PageTransitionWrapper>{children}</PageTransitionWrapper>
         </div>
+
+        {/* Credit — fixed, unobtrusive, always present */}
+        <CreditLink />
       </body>
     </html>
   );

--- a/apps/web/src/components/ui/CreditLink.tsx
+++ b/apps/web/src/components/ui/CreditLink.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+export default function CreditLink() {
+  return (
+    <a
+      href="https://linkedin.com/in/ido-sagiv"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="credit-link"
+    >
+      Made by Ido Sagiv
+    </a>
+  );
+}


### PR DESCRIPTION
Adds a fixed bottom-center 'Made by Ido Sagiv' credit on every page.

- Links to linkedin.com/in/ido-sagiv (opens in new tab)
- 10px, muted opacity (25%), hover brightens to 70%
- Pure CSS hover via globals.css (no JS)
- Implemented as `CreditLink` client component in root layout