### PR TITLE
fix: correct LinkedIn URL in credit link

### DIFF
--- a/apps/web/src/components/ui/CreditLink.tsx
+++ b/apps/web/src/components/ui/CreditLink.tsx
@@ -3,7 +3,7 @@
 export default function CreditLink() {
   return (
     <a
-      href="https://linkedin.com/in/ido-sagiv"
+      href="https://linkedin.com/in/ido-sagiv-a764a6136"
       target="_blank"
       rel="noopener noreferrer"
       className="credit-link"


### PR DESCRIPTION
Fixes the credit link URL from `ido-sagiv` to `ido-sagiv-a764a6136`.