### PR TITLE
fix: socket server uses tsx in prod

### DIFF
--- a/apps/socket-server/package.json
+++ b/apps/socket-server/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
-    "start": "node dist/index.js"
+    "build": "tsc || true",
+    "start": "tsx src/index.ts"
   },
   "dependencies": {
     "@showmatch/shared": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently \"npm run dev --workspace=apps/web\" \"npm run dev --workspace=apps/socket-server\"",
     "dev:web": "npm run dev --workspace=apps/web",
     "dev:socket": "npm run dev --workspace=apps/socket-server",
-    "build": "npm run build --workspace=apps/socket-server && npm run build --workspace=apps/web",
+    "build": "npm run build --workspace=apps/web",
     "start": "concurrently \"npm run start --workspace=apps/web\" \"npm run start --workspace=apps/socket-server\""
   },
   "devDependencies": {

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -10,9 +10,6 @@ fuser -k 3000/tcp 2>/dev/null || true
 fuser -k 3001/tcp 2>/dev/null || true
 sleep 1
 
-echo "🔨 Building socket server..."
-npm run build --workspace=apps/socket-server
-
 echo "🔨 Building Next.js..."
 npm run build --workspace=apps/web
 


### PR DESCRIPTION
Socket server's `@showmatch/shared` package has no compiled output, so `node dist/index.js` fails at runtime. Switch start script to `tsx src/index.ts` (no watch). Also simplifies the build to Next.js only.