### PR TITLE
fix: winner reveal auto-scroll and confetti visibility

### DIFF
--- a/apps/web/src/app/results/[code]/page.tsx
+++ b/apps/web/src/app/results/[code]/page.tsx
@@ -35,6 +35,14 @@ export default function ResultsPage() {
     }
   }, [gameOver, matchedTitles, winner, setWinner]);
 
+  // Scroll to top on mount — page can arrive scrolled (browser scroll restoration,
+  // or game page was scrolled when game ended)
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
+    }
+  }, []);
+
   // Save to history when winner is determined
   useEffect(() => {
     if (winner && room && !historySaved) {

--- a/apps/web/src/components/results/Confetti.tsx
+++ b/apps/web/src/components/results/Confetti.tsx
@@ -4,44 +4,51 @@ import { useEffect } from 'react';
 
 export default function Confetti() {
   useEffect(() => {
-    import('canvas-confetti').then(mod => {
-      const confetti = mod.default;
-      const duration = 1500;
-      const end = Date.now() + duration;
+    // Slight delay so the reveal animation completes and the page is scrolled to top
+    const delay = setTimeout(() => {
+      // Scroll to top so confetti is visible (page may have content below)
+      window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
 
-      // Burst from both sides — useWorker:false for mobile compat
-      // (cast to any to bypass outdated type definitions)
-      const fire = (opts: object) =>
+      import('canvas-confetti').then(mod => {
+        const confetti = mod.default;
+        const duration = 2500;
+        const end = Date.now() + duration;
+
+        // Burst from both sides — useWorker:false for mobile compat
+        const fire = (opts: object) =>
+          (confetti as any)({
+            particleCount: 6,
+            spread: 60,
+            ticks: 200,
+            gravity: 1.2,
+            scalar: 1.1,
+            colors: ['#e50914', '#ffd700', '#00c853', '#ffffff', '#ff69b4'],
+            disableForReducedMotion: true,
+            useWorker: false,
+            ...opts,
+          });
+
+        const frame = () => {
+          fire({ angle: 60, origin: { x: 0, y: 0.65 } });
+          fire({ angle: 120, origin: { x: 1, y: 0.65 } });
+          if (Date.now() < end) requestAnimationFrame(frame);
+        };
+
+        // Big initial burst from the center
         (confetti as any)({
-          particleCount: 4,
-          spread: 55,
-          ticks: 150,
-          gravity: 1.4,
-          scalar: 1.0,
-          colors: ['#e50914', '#ffd700', '#00c853', '#ffffff', '#ff69b4'],
+          particleCount: 120,
+          spread: 100,
+          origin: { y: 0.55 },
+          colors: ['#e50914', '#ffd700', '#00c853', '#ffffff'],
           disableForReducedMotion: true,
           useWorker: false,
-          ...opts,
         });
 
-      const frame = () => {
-        fire({ angle: 60, origin: { x: 0, y: 0.6 } });
-        fire({ angle: 120, origin: { x: 1, y: 0.6 } });
-        if (Date.now() < end) requestAnimationFrame(frame);
-      };
-
-      // Initial burst (lighter than before)
-      (confetti as any)({
-        particleCount: 50,
-        spread: 90,
-        origin: { y: 0.5 },
-        colors: ['#e50914', '#ffd700', '#00c853'],
-        disableForReducedMotion: true,
-        useWorker: false,
+        frame();
       });
+    }, 300);
 
-      frame();
-    });
+    return () => clearTimeout(delay);
   }, []);
 
   return null;

--- a/apps/web/src/components/results/ResultReveal.tsx
+++ b/apps/web/src/components/results/ResultReveal.tsx
@@ -27,8 +27,10 @@ export default function ResultReveal({ winner, skipCountdown = false }: ResultRe
   }, [countdown, skipCountdown]);
 
   useEffect(() => {
-    if (revealed && !skipCountdown) {
-      playSound('victory');
+    if (revealed) {
+      if (!skipCountdown) playSound('victory');
+      // Make sure the top of the page is visible so the winner card + confetti are seen
+      window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [revealed]);


### PR DESCRIPTION
Two related bugs on the results screen:

1. **Auto-scroll**: SwipeReveal + GameStats render immediately with the winner, making the page tall. Browser scroll restoration or scroll position from game page was landing users mid-page.
2. **Confetti invisible**: page was scrolled past the winner card when confetti fired. Also, production runs effects once (dev ran twice via StrictMode), halving the visual impact.

Fixes: explicit scroll-to-top on results mount + on reveal, 300ms confetti delay, bigger initial burst.