### PR TITLE
feat: Vercel + Fly.io cloud deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+apps/web
+scripts
+*.md
+.env*

--- a/README.md
+++ b/README.md
@@ -183,6 +183,46 @@ showmatch/
 
 ---
 
+## Cloud Deployment (free)
+
+Frontend → **Vercel** · Socket server → **Fly.io**
+
+### Socket server — Fly.io
+
+```bash
+# Install Fly CLI (once)
+curl -L https://fly.io/install.sh | sh
+
+# From repo root:
+fly launch --no-deploy        # creates app, sets name in fly.toml
+fly secrets set \
+  TMDB_READ_ACCESS_TOKEN=eyJ... \
+  OMDB_API_KEY=abc12345
+fly deploy                    # builds Docker image + deploys
+```
+
+Once deployed, your socket URL will be `https://<app-name>.fly.dev`.
+
+> `auto_stop_machines = false` in `fly.toml` keeps the machine always-on (in-memory rooms can't survive restarts). Fly's free tier covers 1 shared VM.
+
+### Frontend — Vercel
+
+1. Import the GitHub repo at [vercel.com/new](https://vercel.com/new)
+2. Set **Root Directory** → `apps/web`
+3. Add environment variables:
+
+| Variable | Value |
+|---|---|
+| `NEXT_PUBLIC_SOCKET_URL` | `https://<your-fly-app>.fly.dev` |
+| `TMDB_READ_ACCESS_TOKEN` | your TMDB JWT |
+| `OMDB_API_KEY` | your OMDB key |
+
+4. Deploy — every push to `main` auto-deploys.
+
+> If you later change the Fly.io URL, update `NEXT_PUBLIC_SOCKET_URL` in Vercel and redeploy.
+
+---
+
 ## License
 
 MIT

--- a/apps/socket-server/Dockerfile
+++ b/apps/socket-server/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22-alpine
+WORKDIR /app
+
+# ── 1. Workspace manifests ────────────────────────────────────────────────────
+COPY package.json package-lock.json ./
+COPY packages/shared/package.json ./packages/shared/package.json
+COPY apps/socket-server/package.json ./apps/socket-server/package.json
+
+# Stub apps/web so the root workspaces array doesn't error on a missing dir
+RUN mkdir -p apps/web && \
+    printf '{"name":"showmatch-web","version":"0.0.0","private":true}' \
+    > apps/web/package.json
+
+# ── 2. Install ────────────────────────────────────────────────────────────────
+# Install socket-server + shared deps (includes devDeps so tsx is available)
+RUN npm install --workspace=apps/socket-server --workspace=packages/shared
+
+# ── 3. Source ─────────────────────────────────────────────────────────────────
+COPY packages/shared/ ./packages/shared/
+COPY apps/socket-server/src ./apps/socket-server/src
+COPY apps/socket-server/tsconfig.json ./apps/socket-server/tsconfig.json
+
+EXPOSE 3001
+ENV NODE_ENV=production
+
+CMD ["npm", "run", "start", "--workspace=apps/socket-server"]

--- a/apps/socket-server/src/index.ts
+++ b/apps/socket-server/src/index.ts
@@ -10,8 +10,11 @@ import { registerRankingHandlers } from './handlers/rankingHandler';
 dotenv.config();
 
 const app = express();
-// Allow any origin — this app runs on a private LAN / Tailscale VPN
+// Allow any origin — LAN / cloud deployment
 app.use(cors({ origin: true }));
+
+// Health check for Fly.io / load balancers
+app.get('/health', (_req, res) => res.json({ ok: true }));
 
 const httpServer = createServer(app);
 const io = new Server(httpServer, {

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,38 @@
+# ── ShowMatch Socket Server — Fly.io config ───────────────────────────────────
+# Before first deploy:
+#   1. Run: fly launch --no-deploy  (generates a unique app name + provisions)
+#   2. Run: fly secrets set TMDB_READ_ACCESS_TOKEN=... OMDB_API_KEY=...
+#   3. Run: fly deploy
+
+app = "showmatch-socket"   # ← replace with your fly app name after `fly launch`
+primary_region = "cdg"     # cdg=Paris | iad=Virginia | lax=LA | nrt=Tokyo
+
+[build]
+  dockerfile = "apps/socket-server/Dockerfile"
+
+[http_service]
+  internal_port    = 3001
+  force_https      = true
+  auto_stop_machines  = false   # keep alive — in-memory state must not reset
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type       = "connections"
+    hard_limit = 500
+    soft_limit = 400
+
+[[vm]]
+  memory   = "256mb"
+  cpu_kind = "shared"
+  cpus     = 1
+
+[checks]
+  [checks.health]
+    grace_period = "10s"
+    interval     = "15s"
+    method       = "get"
+    path         = "/health"
+    port         = 3001
+    timeout      = "5s"
+    type         = "http"


### PR DESCRIPTION
Adds everything needed to deploy ShowMatch publicly for free:
- **Dockerfile** for the socket server (monorepo-aware, tsx runtime)
- **fly.toml** with always-on config + health checks
- **.dockerignore** scoped to socket server needs
- **/health** endpoint on the socket server
- **README** cloud deployment section