### PR TITLE
fix: add @types/node for Vercel deployment

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/canvas-confetti": "^1.6.4",
     "@types/howler": "^2.2.11",
+    "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
       "devDependencies": {
         "@types/canvas-confetti": "^1.6.4",
         "@types/howler": "^2.2.11",
+        "@types/node": "^20.0.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "autoprefixer": "^10.4.0",
@@ -56,6 +57,23 @@
         "tailwindcss": "^3.4.0",
         "typescript": "^5.3.0"
       }
+    },
+    "apps/web/node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "apps/web/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",


### PR DESCRIPTION
Next.js TypeScript build requires @types/node. Works locally (hoisted from Pi's global install), fails on Vercel's clean environment.