### PR TITLE
fix: credit link on home page inline, share result with app URL

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -183,19 +183,12 @@ input[type="range"].range-thumb::-moz-range-track {
 
 /* ─── Credit link ──────────────────────────────────────────── */
 .credit-link {
-  position: fixed;
-  bottom: 10px;
-  left: 0;
-  right: 0;
-  text-align: center;
-  z-index: 9999;
   font-size: 10px;
   letter-spacing: 0.05em;
-  color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.22);
   text-decoration: none;
-  pointer-events: auto;
   transition: color 0.2s;
 }
 .credit-link:hover {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.65);
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import PageTransitionWrapper from '@/components/ui/PageTransitionWrapper';
-import CreditLink from '@/components/ui/CreditLink';
 
 export const metadata: Metadata = {
   title: 'ShowMatch · Swipe. Match. Watch.',
@@ -45,8 +44,6 @@ export default function RootLayout({
           <PageTransitionWrapper>{children}</PageTransitionWrapper>
         </div>
 
-        {/* Credit — fixed, unobtrusive, always present */}
-        <CreditLink />
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import { clearSession } from '@/lib/session';
 import JoinGameForm from '@/components/landing/JoinGameForm';
 import GameHistoryButton from '@/components/landing/GameHistoryButton';
 import Logo from '@/components/ui/Logo';
+import CreditLink from '@/components/ui/CreditLink';
 
 /** Decorative poster cards for the right panel (TMDB public CDN) */
 const POSTER_CARDS = [
@@ -146,6 +147,10 @@ export default function Home() {
             >
               <GameHistoryButton />
             </motion.div>
+
+            <div className="mt-4 flex justify-center">
+              <CreditLink />
+            </div>
           </motion.div>
         </div>
 

--- a/apps/web/src/components/results/ShareResultButton.tsx
+++ b/apps/web/src/components/results/ShareResultButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import type { TitleCard } from '@/types/game';
 import Button from '@/components/ui/Button';
-import { safeCopy } from '@/lib/clipboard';
+import { shareText } from '@/lib/share';
 
 interface ShareResultButtonProps {
   winner: TitleCard;
@@ -13,18 +13,15 @@ export default function ShareResultButton({ winner }: ShareResultButtonProps) {
   const [copied, setCopied] = useState(false);
 
   const handleShare = async () => {
-    const text = `We're watching "${winner.title}" (${winner.year})! Decided on ShowMatch 🎬`;
-
-    if (navigator.share) {
-      try {
-        await navigator.share({ title: 'ShowMatch Result', text });
-        return;
-      } catch {}
+    const appUrl = typeof window !== 'undefined' ? window.location.origin : '';
+    const result = await shareText(
+      `We're watching "${winner.title}" (${winner.year})! Decided on ShowMatch 🎬`,
+      { title: 'ShowMatch Result', url: appUrl },
+    );
+    if (result === 'copied') {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     }
-
-    await safeCopy(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
   };
 
   return (

--- a/apps/web/src/components/ui/CreditLink.tsx
+++ b/apps/web/src/components/ui/CreditLink.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+/**
+ * Inline (non-fixed) credit link — place inside a page's flow, not in layout.
+ */
 export default function CreditLink() {
   return (
     <a


### PR DESCRIPTION
## Changes

### Credit link
- Removed from global `layout.tsx` (was `position:fixed; bottom:10px; z-index:9999` — sat on top of the results action bar and covered swipe buttons)
- Now lives inline at the bottom of the home page left pane, below Game History
- No fixed positioning, no z-index, zero conflict with anything

### Share Result
- `ShareResultButton` now uses `shareText()` with the app `window.location.origin` as URL
- Web Share API shows the link as a proper URL preview in the native share sheet
- WhatsApp / clipboard fallback appends the URL to the text