### PR TITLE
feat: cloud deploy script + updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Starts both servers with hot-reload:
 
 > Pages compile on first visit in dev mode — expect a 1–2 s pause the first time you navigate to each screen.
 
-### Production (Raspberry Pi / always-on LAN server)
+### Local production (Raspberry Pi / always-on LAN server)
 
 Build once, then start. Pages are pre-compiled — navigation is instant.
 
@@ -185,41 +185,74 @@ showmatch/
 
 ## Cloud Deployment (free)
 
-Frontend → **Vercel** · Socket server → **Fly.io**
+| Service | Hosts | Cost |
+|---|---|---|
+| **Fly.io** | Socket server | Free — 1 shared-CPU VM, always-on |
+| **Vercel** | Next.js frontend | Free — global CDN, auto-deploys from `main` |
 
-### Socket server — Fly.io
+---
+
+### First-time setup
+
+#### 1. Socket server — Fly.io
 
 ```bash
 # Install Fly CLI (once)
 curl -L https://fly.io/install.sh | sh
 
-# From repo root:
-fly launch --no-deploy        # creates app, sets name in fly.toml
+# From repo root — provision the app (sets a unique name + region):
+fly launch --no-deploy
+
+# Edit fly.toml: replace app = "showmatch-socket" with the name Fly assigned.
+
+# Set secrets (never committed to git):
 fly secrets set \
   TMDB_READ_ACCESS_TOKEN=eyJ... \
   OMDB_API_KEY=abc12345
-fly deploy                    # builds Docker image + deploys
+
+# First deploy:
+fly deploy
 ```
 
-Once deployed, your socket URL will be `https://<app-name>.fly.dev`.
+Your socket server will be live at `https://<app-name>.fly.dev`.
 
-> `auto_stop_machines = false` in `fly.toml` keeps the machine always-on (in-memory rooms can't survive restarts). Fly's free tier covers 1 shared VM.
+> `auto_stop_machines = false` in `fly.toml` keeps the VM always-on. In-memory room state is lost on restarts, so the machine must never spin down mid-game.
 
-### Frontend — Vercel
+#### 2. Frontend — Vercel
 
 1. Import the GitHub repo at [vercel.com/new](https://vercel.com/new)
 2. Set **Root Directory** → `apps/web`
 3. Add environment variables:
 
-| Variable | Value |
+| Variable | Value | When used |
+|---|---|---|
+| `NEXT_PUBLIC_SOCKET_URL` | `https://<your-fly-app>.fly.dev` | Build-time (baked into client bundle) |
+| `TMDB_READ_ACCESS_TOKEN` | your TMDB JWT | Server-side API routes |
+| `OMDB_API_KEY` | your OMDB key | Server-side API routes |
+
+4. Click **Deploy** — every subsequent push to `main` redeploys automatically.
+
+> `NEXT_PUBLIC_SOCKET_URL` is baked in at build time. If you change the Fly.io app name, update this variable in Vercel and trigger a redeploy.
+
+---
+
+### Deploying updates
+
+After merging changes to `main`, run the deploy script from the repo root:
+
+```bash
+bash scripts/deploy.sh
+```
+
+The script enforces three guards before touching anything:
+
+| Guard | What it checks |
 |---|---|
-| `NEXT_PUBLIC_SOCKET_URL` | `https://<your-fly-app>.fly.dev` |
-| `TMDB_READ_ACCESS_TOKEN` | your TMDB JWT |
-| `OMDB_API_KEY` | your OMDB key |
+| Branch | Must be on `main` |
+| Clean tree | No uncommitted changes |
+| Synced | Local `main` matches `origin/main` exactly (no unpushed or un-pulled commits) |
 
-4. Deploy — every push to `main` auto-deploys.
-
-> If you later change the Fly.io URL, update `NEXT_PUBLIC_SOCKET_URL` in Vercel and redeploy.
+If all guards pass it runs `fly deploy` (builds a fresh Docker image and rolls it out). Vercel picks up the `main` push automatically — no extra step needed.
 
 ---
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────────
+# deploy.sh  —  Deploy ShowMatch to the cloud
+#
+# Deploys:
+#   Socket server  →  Fly.io  (fly deploy, builds Docker image)
+#   Frontend       →  Vercel  (auto-deploys on every push to main — no action needed)
+#
+# Guards (all must pass before anything is deployed):
+#   1. Must be on the main branch
+#   2. Working tree must be clean (no uncommitted changes)
+#   3. Local main must be in sync with origin/main (no unpushed or un-pulled commits)
+#
+# Usage:
+#   bash scripts/deploy.sh
+# ──────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+BOLD='\033[1m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+DIM='\033[2m'
+NC='\033[0m'
+
+echo -e "\n${BOLD}ShowMatch · Cloud Deploy${NC}\n"
+
+# ── Guard 1: must be on main ──────────────────────────────────────────────────
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo -e "${RED}✗ Not on main (currently: ${CURRENT_BRANCH})${NC}"
+  echo -e "  Only main can be deployed. Merge your branch first.\n"
+  exit 1
+fi
+echo -e "${GREEN}✓ Branch: main${NC}"
+
+# ── Guard 2: working tree must be clean ──────────────────────────────────────
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo -e "${RED}✗ Uncommitted changes detected${NC}"
+  echo -e "  Commit or stash before deploying.\n"
+  exit 1
+fi
+echo -e "${GREEN}✓ Working tree clean${NC}"
+
+# ── Guard 3: must be in sync with origin/main ─────────────────────────────────
+echo -e "${DIM}  Fetching origin...${NC}"
+git fetch origin main --quiet
+
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+
+if [ "$LOCAL" != "$REMOTE" ]; then
+  BEHIND=$(git rev-list HEAD..origin/main --count)
+  AHEAD=$(git rev-list origin/main..HEAD --count)
+
+  if [ "$BEHIND" -gt 0 ]; then
+    echo -e "${RED}✗ Local main is $BEHIND commit(s) behind origin/main${NC}"
+    echo -e "  Run: git pull origin main\n"
+    exit 1
+  fi
+  if [ "$AHEAD" -gt 0 ]; then
+    echo -e "${RED}✗ Local main has $AHEAD unpushed commit(s)${NC}"
+    echo -e "  Run: git push origin main\n"
+    exit 1
+  fi
+fi
+
+COMMIT=$(git rev-parse --short HEAD)
+echo -e "${GREEN}✓ In sync with origin/main${NC} ${DIM}($COMMIT)${NC}"
+
+# ── Deploy: socket server → Fly.io ───────────────────────────────────────────
+echo -e "\n${BOLD}Deploying socket server → Fly.io...${NC}"
+
+if ! command -v fly &>/dev/null; then
+  echo -e "${RED}✗ fly CLI not found${NC}"
+  echo -e "  Install: curl -L https://fly.io/install.sh | sh\n"
+  exit 1
+fi
+
+fly deploy
+
+echo -e "\n${GREEN}${BOLD}✓ Socket server deployed${NC}"
+
+# ── Vercel: auto-deploys from main, nothing to do ────────────────────────────
+echo -e "\n${YELLOW}ℹ Vercel picks up main automatically — no action needed.${NC}"
+echo -e "  Track: https://vercel.com/dashboard\n"
+
+echo -e "${GREEN}${BOLD}Deploy complete.${NC} Commit: $COMMIT\n"


### PR DESCRIPTION
## Changes

### `scripts/deploy.sh`
Deploys to Fly.io (socket server) with three pre-flight guards:
1. **Branch check** — must be on `main`
2. **Clean tree** — no uncommitted changes
3. **Sync check** — fetches `origin/main` and verifies local is exactly in sync (rejects both ahead and behind)

If all pass, runs `fly deploy`. Vercel auto-deploys from main push, so no extra step needed. Colored terminal output with actionable error messages.

### README
- First-time cloud setup split into two clear steps (Fly.io then Vercel)
- Added service/cost table
- New 'Deploying updates' section documents `scripts/deploy.sh` and the guard table
- Local section renamed to 'Local production' for clarity