### PR TITLE
fix: deploy script sources FLY_API_TOKEN from shell profile

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,6 +16,11 @@
 # ──────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+# Load tokens from shell profile if not already in environment
+# shellcheck source=/dev/null
+[ -z "${FLY_API_TOKEN:-}" ] && source ~/.bashrc 2>/dev/null || true
+export PATH="$HOME/.fly/bin:$PATH"
+
 BOLD='\033[1m'
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
Sources ~/.bashrc if FLY_API_TOKEN is not already set, so the script works without manually exporting the token first.