### PR TITLE
feat: deploy script covers Vercel + README live URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ showmatch/
 
 ## Cloud Deployment (free)
 
-| Service | Hosts | Cost |
-|---|---|---|
-| **Fly.io** | Socket server | Free — 1 shared-CPU VM, always-on |
-| **Vercel** | Next.js frontend | Free — global CDN, auto-deploys from `main` |
+| Service | Hosts | URL | Cost |
+|---|---|---|---|
+| **Fly.io** | Socket server | `https://showmatch-socket.fly.dev` | Free — 1 shared-CPU VM, always-on |
+| **Vercel** | Next.js frontend | `https://showmatch.vercel.app` | Free — global CDN |
 
 ---
 
@@ -230,9 +230,9 @@ Your socket server will be live at `https://<app-name>.fly.dev`.
 | `TMDB_READ_ACCESS_TOKEN` | your TMDB JWT | Server-side API routes |
 | `OMDB_API_KEY` | your OMDB key | Server-side API routes |
 
-4. Click **Deploy** — every subsequent push to `main` redeploys automatically.
+4. Click **Deploy** — then use `bash scripts/deploy.sh` for all future deploys.
 
-> `NEXT_PUBLIC_SOCKET_URL` is baked in at build time. If you change the Fly.io app name, update this variable in Vercel and trigger a redeploy.
+> `NEXT_PUBLIC_SOCKET_URL` is baked in at build time. If you change the Fly.io app name, update this variable in Vercel and redeploy.
 
 ---
 
@@ -252,7 +252,11 @@ The script enforces three guards before touching anything:
 | Clean tree | No uncommitted changes |
 | Synced | Local `main` matches `origin/main` exactly (no unpushed or un-pulled commits) |
 
-If all guards pass it runs `fly deploy` (builds a fresh Docker image and rolls it out). Vercel picks up the `main` push automatically — no extra step needed.
+If all guards pass it deploys both services in sequence:
+1. **Fly.io** — builds a fresh Docker image and rolls it out (`fly deploy`)
+2. **Vercel** — deploys the Next.js frontend (`vercel deploy --prod`)
+
+> Credentials are read from `~/.showmatch_creds` (not committed to git).
 
 ---
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,10 +84,25 @@ fi
 
 fly deploy
 
-echo -e "\n${GREEN}${BOLD}✓ Socket server deployed${NC}"
+echo -e "\n${GREEN}${BOLD}✓ Socket server deployed → https://showmatch-socket.fly.dev${NC}"
 
-# ── Vercel: auto-deploys from main, nothing to do ────────────────────────────
-echo -e "\n${YELLOW}ℹ Vercel picks up main automatically — no action needed.${NC}"
-echo -e "  Track: https://vercel.com/dashboard\n"
+# ── Deploy: frontend → Vercel ────────────────────────────────────────────────
+echo -e "\n${BOLD}Deploying frontend → Vercel...${NC}"
 
-echo -e "${GREEN}${BOLD}Deploy complete.${NC} Commit: $COMMIT\n"
+if ! command -v vercel &>/dev/null; then
+  echo -e "${RED}✗ vercel CLI not found${NC}"
+  echo -e "  Install: npm install -g vercel\n"
+  exit 1
+fi
+
+if [ -z "${VERCEL_TOKEN:-}" ]; then
+  echo -e "${RED}✗ VERCEL_TOKEN not set${NC}"
+  exit 1
+fi
+
+vercel deploy --prod --token "$VERCEL_TOKEN" --yes
+
+echo -e "\n${GREEN}${BOLD}✓ Frontend deployed → https://showmatch.vercel.app${NC}"
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo -e "\n${GREEN}${BOLD}Deploy complete.${NC} Commit: $COMMIT\n"


### PR DESCRIPTION
Since the Vercel project isn't connected to GitHub, `vercel deploy --prod` must be run explicitly. The deploy script now does both in sequence: Fly.io then Vercel. README updated with production URLs.