### PR TITLE
chore: clarify local vs cloud production scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ OMDB_API_KEY=abc12345
 
 ---
 
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `npm run dev` | Development — hot-reload, both servers |
+| `bash scripts/prod.sh` | **Local production** — rebuild + restart on the Pi (LAN only) |
+| `bash scripts/deploy.sh` | **Cloud production** — deploy to Fly.io + Vercel |
+
+---
+
 ## Running
 
 ### Development

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # ──────────────────────────────────────────────────────────────────────────────
-# deploy.sh  —  Deploy ShowMatch to the cloud
+# deploy.sh  —  CLOUD production (Fly.io + Vercel)
 #
 # Deploys:
 #   Socket server  →  Fly.io  (fly deploy, builds Docker image)
-#   Frontend       →  Vercel  (auto-deploys on every push to main — no action needed)
+#   Frontend       →  Vercel  (vercel deploy --prod)
 #
 # Guards (all must pass before anything is deployed):
 #   1. Must be on the main branch
 #   2. Working tree must be clean (no uncommitted changes)
 #   3. Local main must be in sync with origin/main (no unpushed or un-pulled commits)
+#
+# For LOCAL production (Raspberry Pi / LAN) use: bash scripts/prod.sh
 #
 # Usage:
 #   bash scripts/deploy.sh

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-# Build and start ShowMatch in production mode.
-# Run from repo root: bash scripts/prod.sh
+# ──────────────────────────────────────────────────────────────────────────────
+# prod.sh  —  LOCAL production (Raspberry Pi / LAN)
+#
+# Kills any running servers, rebuilds Next.js, and restarts both servers
+# in the background. Logs go to /tmp/showmatch-prod.log.
+#
+# For CLOUD deployment (Fly.io + Vercel) use: bash scripts/deploy.sh
+# ──────────────────────────────────────────────────────────────────────────────
 set -e
 
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
Headers on both scripts and a README quick-reference table make the distinction explicit.