### PR TITLE
fix: credit link global + fixed bottom-right + LinkedIn link works

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -183,11 +183,16 @@ input[type="range"].range-thumb::-moz-range-track {
 
 /* ─── Credit link ──────────────────────────────────────────── */
 .credit-link {
+  position: fixed;
+  bottom: max(8px, env(safe-area-inset-bottom));
+  right: 12px;
+  z-index: 9999;
   font-size: 10px;
   letter-spacing: 0.05em;
   color: rgba(255, 255, 255, 0.22);
   text-decoration: none;
   transition: color 0.2s;
+  pointer-events: auto;
 }
 .credit-link:hover {
   color: rgba(255, 255, 255, 0.65);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import PageTransitionWrapper from '@/components/ui/PageTransitionWrapper';
+import CreditLink from '@/components/ui/CreditLink';
 
 export const metadata: Metadata = {
   title: 'ShowMatch · Swipe. Match. Watch.',
@@ -44,6 +45,7 @@ export default function RootLayout({
           <PageTransitionWrapper>{children}</PageTransitionWrapper>
         </div>
 
+        <CreditLink />
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,7 +7,6 @@ import { clearSession } from '@/lib/session';
 import JoinGameForm from '@/components/landing/JoinGameForm';
 import GameHistoryButton from '@/components/landing/GameHistoryButton';
 import Logo from '@/components/ui/Logo';
-import CreditLink from '@/components/ui/CreditLink';
 
 /** Decorative poster cards for the right panel (TMDB public CDN) */
 const POSTER_CARDS = [
@@ -39,11 +38,6 @@ export default function Home() {
 
   return (
     <main className="min-h-screen relative overflow-hidden flex flex-col">
-
-      {/* Credit — top right, home page only */}
-      <div className="absolute top-3 right-4 z-10">
-        <CreditLink />
-      </div>
 
       {/* ── Atmospheric blobs ── */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">


### PR DESCRIPTION
Restores CreditLink to layout.tsx as fixed bottom-right. Fixes broken LinkedIn link (content layer was covering the inline element).