### PR TITLE
fix: credit z-index below action bars

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -186,7 +186,7 @@ input[type="range"].range-thumb::-moz-range-track {
   position: fixed;
   bottom: max(8px, env(safe-area-inset-bottom));
   right: 12px;
-  z-index: 9999;
+  z-index: 9;
   font-size: 10px;
   letter-spacing: 0.05em;
   color: rgba(255, 255, 255, 0.22);


### PR DESCRIPTION
z-index: 9999 → 9. Results action bar (z-10) renders on top so buttons are tappable. Credit still visible on all other screens.