### PR TITLE
fix: credit link home-page-only inline (no overlap)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -183,16 +183,11 @@ input[type="range"].range-thumb::-moz-range-track {
 
 /* ─── Credit link ──────────────────────────────────────────── */
 .credit-link {
-  position: fixed;
-  bottom: max(8px, env(safe-area-inset-bottom));
-  right: 12px;
-  z-index: 9;
   font-size: 10px;
   letter-spacing: 0.05em;
   color: rgba(255, 255, 255, 0.22);
   text-decoration: none;
   transition: color 0.2s;
-  pointer-events: auto;
 }
 .credit-link:hover {
   color: rgba(255, 255, 255, 0.65);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import PageTransitionWrapper from '@/components/ui/PageTransitionWrapper';
-import CreditLink from '@/components/ui/CreditLink';
 
 export const metadata: Metadata = {
   title: 'ShowMatch · Swipe. Match. Watch.',
@@ -45,7 +44,6 @@ export default function RootLayout({
           <PageTransitionWrapper>{children}</PageTransitionWrapper>
         </div>
 
-        <CreditLink />
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import { clearSession } from '@/lib/session';
 import JoinGameForm from '@/components/landing/JoinGameForm';
 import GameHistoryButton from '@/components/landing/GameHistoryButton';
 import Logo from '@/components/ui/Logo';
+import CreditLink from '@/components/ui/CreditLink';
 
 /** Decorative poster cards for the right panel (TMDB public CDN) */
 const POSTER_CARDS = [
@@ -146,6 +147,10 @@ export default function Home() {
             >
               <GameHistoryButton />
             </motion.div>
+
+            <div className="mt-4 pb-4 flex justify-center">
+              <CreditLink />
+            </div>
           </motion.div>
         </div>
 


### PR DESCRIPTION
Removed from layout. Inline in-flow element at home page bottom — z-index-free, impossible to overlap.