### PR TITLE
perf: pre-warm socket on home page

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import CreateGameButton from '@/components/landing/CreateGameButton';
 import { clearSession } from '@/lib/session';
+import { connectSocket } from '@/lib/socket';
 import JoinGameForm from '@/components/landing/JoinGameForm';
 import GameHistoryButton from '@/components/landing/GameHistoryButton';
 import Logo from '@/components/ui/Logo';
@@ -35,6 +36,11 @@ export default function Home() {
       sessionStorage.removeItem('showmatch-toast');
       setTimeout(() => setToast(null), 4000);
     }
+    // Pre-warm the socket connection while the user reads the home page.
+    // By the time they tap Create Game / enter their name, the TCP+TLS+WS
+    // handshake is already done and the first emit fires immediately.
+    // (No cleanup — leave connected so /create inherits the live socket.)
+    connectSocket();
   }, []);
 
   return (

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -20,7 +20,7 @@ export function useSocket() {
     // On every (re)connect: try to re-attach to an active room.
     // • First connect + session in sessionStorage → page refresh case
     // • Re-connect (socket dropped) + room in Zustand → brief disconnect case
-    socket.on('connect', () => {
+    const handleConnect = () => {
       if (!everConnectedRef.current) {
         everConnectedRef.current = true;
         // Page-refresh case: Zustand is empty but sessionStorage may have a session
@@ -44,7 +44,12 @@ export function useSocket() {
       const me = room.players.find(p => p.id === playerId);
       if (!me) return;
       socket.emit('rejoinGame', { code: room.code, displayName: me.displayName });
-    });
+    };
+
+    socket.on('connect', handleConnect);
+    // Socket may already be connected (pre-warmed from home page).
+    // The 'connect' event won't fire again — run the handler immediately.
+    if (socket.connected) handleConnect();
 
     socket.on('playerJoined', (player) => {
       store.addPlayer(player);
@@ -169,7 +174,7 @@ export function useSocket() {
     });
 
     return () => {
-      socket.off('connect');
+      socket.off('connect', handleConnect);
       socket.off('playerJoined');
       socket.off('playerLeft');
       socket.off('settingsUpdated');

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -18,6 +18,10 @@ export function getSocket(): TypedSocket {
         : 'http://localhost:3001');
     socket = io(url, {
       autoConnect: false,
+      // Start directly with WebSocket — skips the HTTP long-poll handshake
+      // that socket.io normally uses before upgrading. Saves 2–3 round-trips
+      // on initial connect (~200–400ms on a cloud server).
+      // Falls back to polling if WebSocket is blocked.
       transports: ['websocket', 'polling'],
     }) as TypedSocket;
   }


### PR DESCRIPTION
Eliminates the create-game freeze. Socket connects while user reads the home page; by the time they tap Create Game and enter a name, the handshake is done.