### PR TITLE
fix: lobby refresh rejoins correctly, no ghost players

### DIFF
--- a/apps/socket-server/src/handlers/roomHandler.ts
+++ b/apps/socket-server/src/handlers/roomHandler.ts
@@ -41,9 +41,11 @@ export function registerRoomHandlers(io: Server, socket: Socket) {
       socket.emit('roomClosed', 'Connection lost. The room no longer exists.');
       return;
     }
-    const { room } = result;
+    const { room, player } = result;
     socket.join(room.code);
     console.log(`[rejoinGame] ${displayName} re-attached to room ${room.code}`);
+    // Notify other players so their UI reflects the reconnected state
+    socket.to(room.code).emit('playerRejoined', player);
     socket.emit('gameRejoined', roomManager.serializeRoom(room), room.titlePool);
   });
 

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -59,6 +59,10 @@ export function useSocket() {
       store.removePlayer(playerId);
     });
 
+    (socket as any).on('playerRejoined', (player: any) => {
+      store.updatePlayer(player);
+    });
+
     socket.on('settingsUpdated', (settings) => {
       store.updateSettings(settings);
     });
@@ -177,6 +181,7 @@ export function useSocket() {
       socket.off('connect', handleConnect);
       socket.off('playerJoined');
       socket.off('playerLeft');
+      (socket as any).off('playerRejoined');
       socket.off('settingsUpdated');
       socket.off('gameStarted');
       socket.off('playerProgress');

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -27,6 +27,7 @@ interface GameStore {
   updatePlayers: (players: Player[]) => void;
   addPlayer: (player: Player) => void;
   removePlayer: (playerId: string) => void;
+  updatePlayer: (player: Player) => void;
   updateSettings: (settings: GameSettings) => void;
   startGame: (titlePool: TitleCard[]) => void;
   recordSwipe: (decision: SwipeDecision) => void;
@@ -64,7 +65,13 @@ const initialState = {
   isFirstMatch: false,
   loadingProgress: null as { stage: string; progress: number; total?: number } | null,
   gameOver: false,
-  reconnecting: false,
+  // Initialise as `true` on the client if a session exists in sessionStorage.
+  // This prevents lobby/game pages from redirecting away before the socket
+  // has had a chance to connect and fire rejoinGame. The value is synchronous
+  // so it beats any useEffect timing race.
+  reconnecting: typeof window !== 'undefined'
+    ? !!sessionStorage.getItem('showmatch-session')
+    : false,
 };
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -85,6 +92,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
     room: state.room ? {
       ...state.room,
       players: state.room.players.filter(p => p.id !== playerId),
+    } : null,
+  })),
+
+  updatePlayer: (player) => set((state) => ({
+    room: state.room ? {
+      ...state.room,
+      players: state.room.players.map(p => p.id === player.id ? player : p),
     } : null,
   })),
 


### PR DESCRIPTION
Two bugs fixed. Refresh from lobby now shows 'Reconnecting...' and returns to the correct page. Owner's player list stays in sync on reconnect.