### PR TITLE
fix: streaming providers hardcoded to US

### DIFF
--- a/apps/web/src/components/lobby/FilterPanel.tsx
+++ b/apps/web/src/components/lobby/FilterPanel.tsx
@@ -4,25 +4,6 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { motion } from 'framer-motion';
 import type { GameSettings, StreamingProvider } from '@/types/game';
 import { GENRES, CONTENT_RATINGS, TIMER_OPTIONS, SORT_OPTIONS } from '@/lib/constants';
-
-const REGIONS: { code: string; name: string }[] = [
-  { code: 'IL', name: 'Israel' },
-  { code: 'US', name: 'USA' },
-  { code: 'GB', name: 'UK' },
-  { code: 'CA', name: 'Canada' },
-  { code: 'AU', name: 'Australia' },
-  { code: 'DE', name: 'Germany' },
-  { code: 'FR', name: 'France' },
-  { code: 'NL', name: 'Netherlands' },
-  { code: 'ES', name: 'Spain' },
-  { code: 'IT', name: 'Italy' },
-  { code: 'BR', name: 'Brazil' },
-  { code: 'MX', name: 'Mexico' },
-  { code: 'IN', name: 'India' },
-  { code: 'JP', name: 'Japan' },
-  { code: 'KR', name: 'South Korea' },
-];
-import { detectRegion } from '@/lib/detectRegion';
 import YearRangeSlider from '@/components/ui/YearRangeSlider';
 
 interface FilterPanelProps {
@@ -51,24 +32,12 @@ export default function FilterPanel({ settings, onSettingsChange, isCreator }: F
     setProviderTooltip(null);
   }, []);
 
-  // Auto-detect region from browser locale / timezone on first mount
-  const regionDetected = useRef(false);
   useEffect(() => {
-    if (!isCreator || regionDetected.current) return;
-    regionDetected.current = true;
-    const detected = detectRegion();
-    if (detected !== settings.region) {
-      onSettingsChange({ ...settings, region: detected });
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCreator]);
-
-  useEffect(() => {
-    fetch(`/api/tmdb/providers?region=${settings.region}`)
+    fetch('/api/tmdb/providers?region=US')
       .then(res => res.json())
       .then(data => setProviders(data))
       .catch(() => {});
-  }, [settings.region]);
+  }, []);
 
   const update = useCallback((partial: Partial<GameSettings>) => {
     if (!isCreator) return;
@@ -128,25 +97,7 @@ export default function FilterPanel({ settings, onSettingsChange, isCreator }: F
       {/* Streaming Providers */}
       <div>
         <div className="flex justify-between items-center mb-2">
-          <label className="text-sm text-gray-400 flex items-center gap-1.5">
-            Streaming Services
-            {isCreator ? (
-              <select
-                value={settings.region}
-                onChange={e => update({ region: e.target.value, providers: [] })}
-                className="bg-dark-surface border border-dark-border rounded px-1 py-0.5 text-[10px] text-gray-400 font-mono cursor-pointer focus:outline-none focus:border-primary appearance-none"
-                title="Change region"
-              >
-                {REGIONS.map(r => (
-                  <option key={r.code} value={r.code}>{r.code} · {r.name}</option>
-                ))}
-              </select>
-            ) : (
-              <span className="px-1.5 py-0.5 bg-dark-surface border border-dark-border rounded text-[10px] text-gray-500 font-mono">
-                {settings.region}
-              </span>
-            )}
-          </label>
+          <label className="text-sm text-gray-400">Streaming Services</label>
           <div className="flex gap-2">
             <button onClick={() => update({ providers: providers.map(p => p.id) })} className="text-xs text-primary">All</button>
             <button onClick={() => update({ providers: [] })} className="text-xs text-gray-500">Clear</button>


### PR DESCRIPTION
Remove region picker. US providers shown for everyone — covers Netflix, Disney+, Hulu, HBO Max, Apple TV+, Peacock, etc.