### PR TITLE
fix: results screen scroll through cards on touch

### DIFF
--- a/apps/web/src/components/game/SwipeCard.tsx
+++ b/apps/web/src/components/game/SwipeCard.tsx
@@ -144,7 +144,7 @@ export default function SwipeCard({
       <motion.div
         className="relative cursor-grab active:cursor-grabbing select-none h-full"
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        style={{ x, y, rotate, touchAction: flipped ? 'pan-y' : 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', willChange: 'transform' } as any}
+        style={{ x, y, rotate, touchAction: (preview || flipped) ? 'pan-y' : 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', willChange: 'transform' } as any}
         drag={!preview && isTop && !exiting ? (flipped ? 'x' : true) : false}
         dragElastic={flipped ? 0.4 : 0.8}
         dragConstraints={flipped ? { top: 0, bottom: 0 } : undefined}

--- a/apps/web/src/components/results/RankingBoard.tsx
+++ b/apps/web/src/components/results/RankingBoard.tsx
@@ -20,6 +20,7 @@ function DraggableItem({ item, index }: { item: TitleCard; index: number }) {
       value={item}
       dragListener={false}
       dragControls={dragControls}
+      style={{ touchAction: 'pan-y' }}
     >
       <motion.div
         className="flex items-center gap-3 bg-dark-card rounded-xl p-3 mb-2 border border-dark-border"


### PR DESCRIPTION
SwipeCard preview mode (winner card) no longer blocks vertical page scroll. RankingBoard rows also fixed.