### PR TITLE
fix: 8s connection timeout on create/join

### DIFF
--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -89,9 +89,26 @@ export default function CreatePage() {
       });
     };
 
-    // Wait for socket if not yet connected (avoids silent hang on first load)
-    if (socket.connected) doCreate();
-    else { socket.once('connect', doCreate); socket.connect(); }
+    // Wait for socket if not yet connected (avoids silent hang on first load).
+    // Guard with a timeout so the button never freezes forever if the server
+    // is unreachable (e.g. Fly.io machine suspended).
+    if (socket.connected) {
+      doCreate();
+    } else {
+      const timeoutId = setTimeout(() => {
+        socket.off('connect', onConnect);
+        setError('Could not reach the server. Please try again in a moment.');
+        setCreating(false);
+      }, 8000);
+
+      const onConnect = () => {
+        clearTimeout(timeoutId);
+        doCreate();
+      };
+
+      socket.once('connect', onConnect);
+      socket.connect();
+    }
   }, [name, socket, setRoom, setPlayerId]);
 
   const handleSettingsChange = useCallback((settings: GameSettings) => {

--- a/apps/web/src/app/join/[code]/page.tsx
+++ b/apps/web/src/app/join/[code]/page.tsx
@@ -40,8 +40,18 @@ export default function JoinPage() {
       });
     };
 
-    if (socket.connected) doCheck();
-    else { socket.once('connect', doCheck); socket.connect(); }
+    if (socket.connected) {
+      doCheck();
+    } else {
+      const timeoutId = setTimeout(() => {
+        socket.off('connect', onConnect);
+        sessionStorage.setItem('showmatch-toast', 'Could not reach the server. Please try again.');
+        router.replace('/');
+      }, 8000);
+      const onConnect = () => { clearTimeout(timeoutId); doCheck(); };
+      socket.once('connect', onConnect);
+      socket.connect();
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -64,8 +74,18 @@ export default function JoinPage() {
       });
     };
 
-    if (socket.connected) doJoin();
-    else { socket.once('connect', doJoin); socket.connect(); }
+    if (socket.connected) {
+      doJoin();
+    } else {
+      const timeoutId = setTimeout(() => {
+        socket.off('connect', onConnect);
+        setError('Could not reach the server. Please try again in a moment.');
+        setJoining(false);
+      }, 8000);
+      const onConnect = () => { clearTimeout(timeoutId); doJoin(); };
+      socket.once('connect', onConnect);
+      socket.connect();
+    }
   };
 
   const handleShuffle = () => {


### PR DESCRIPTION
Prevents infinite spinner when socket server is unreachable. Shows a clear error after 8s.