### PR TITLE
fix: join button stuck loading + background overscroll flash

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,6 +7,10 @@
   --foreground: #ededed;
 }
 
+html {
+  background: #08080f;
+}
+
 body {
   color: var(--foreground);
   background: #08080f;

--- a/apps/web/src/app/join/[code]/page.tsx
+++ b/apps/web/src/app/join/[code]/page.tsx
@@ -61,7 +61,12 @@ export default function JoinPage() {
     setError(null);
 
     const doJoin = () => {
-      socket.emit('joinRoom', code, name.trim(), (response: any) => {
+      socket.timeout(6000).emit('joinRoom', code, name.trim(), (err: Error | null, response: any) => {
+        if (err) {
+          setError('Could not reach the server. Please try again.');
+          setJoining(false);
+          return;
+        }
         if ('error' in response) {
           setError(response.error);
           setJoining(false);


### PR DESCRIPTION
## Bug 1 — Join button stuck in loading state on name taken

**Root cause**: `socket.emit('joinRoom', ...)` acknowledgment callbacks are silently dropped if the socket disconnects mid-flight (e.g. Render cold start wake-up). The `joining` state was never reset, leaving the button in permanent dots mode.

**Fix**: `socket.timeout(6000).emit(...)` — if no ack arrives within 6s, callback fires with an error and `joining` resets.

## Bug 2 — Background white flash on overscroll

**Root cause**: Only `body` had `background: #08080f` — iOS Safari shows the `html` element's background (defaults to white) when rubber-band overscrolling past page boundaries.

**Fix**: Add `html { background: #08080f }` to `globals.css`.