### PR TITLE
fix(veto): advance card and play sound on veto

### DIFF
--- a/apps/web/src/app/game/[code]/page.tsx
+++ b/apps/web/src/app/game/[code]/page.tsx
@@ -104,9 +104,15 @@ export default function GamePage() {
     if (!titlePool[currentCardIndex]) return;
     const tmdbId = titlePool[currentCardIndex].tmdbId;
     socket.emit('vetoTitle', tmdbId);
+    recordSwipe({ tmdbId, decision: 'veto', timestamp: Date.now() });
+    setDragDirection(null);
+    setFlipped(false);
+    setCanUndo(false); // veto can't be undone
+    playPass();
     setShowVetoFlash(true);
     setTimeout(() => setShowVetoFlash(false), 700);
-  }, [socket, titlePool, currentCardIndex]);
+    try { navigator.vibrate?.(80); } catch {}
+  }, [socket, titlePool, currentCardIndex, recordSwipe, setDragDirection, playPass]);
 
   const handleUndo = useCallback(() => {
     const undone = undoLastSwipe();


### PR DESCRIPTION
Veto button was only showing the flash overlay but not advancing the card or playing any sound.

- Added `recordSwipe({ decision: 'veto' })` to increment `currentCardIndex`
- Play pass sound
- Reset flip/drag state; disable undo after veto